### PR TITLE
Rewrite function call operator of LMOCompare class in templated version

### DIFF
--- a/src/Core/LogicModel/LogicModelObjectBase.cc
+++ b/src/Core/LogicModel/LogicModelObjectBase.cc
@@ -121,14 +121,3 @@ const std::string LogicModelObjectBase::get_object_type_name() const
 {
     return tr("Generic object").toStdString();
 }
-
-
-bool LMOCompare::operator()(const LogicModelObjectBase& a, const LogicModelObjectBase& b) const
-{
-    return a.get_object_id() < b.get_object_id();
-}
-
-bool LMOCompare::operator()(const LogicModelObjectBase_shptr& a, const LogicModelObjectBase_shptr& b) const
-{
-    return this->operator()(*a, *b);
-}

--- a/src/Core/LogicModel/LogicModelObjectBase.h
+++ b/src/Core/LogicModel/LogicModelObjectBase.h
@@ -136,19 +136,28 @@ namespace degate
         virtual const std::string get_object_type_name() const;
     };
 
-    typedef std::shared_ptr<LogicModelObjectBase> LogicModelObjectBase_shptr;
-
+    /**
+     * @class LMOCompare
+     * @brief Helper to compare LogicModelObjectBase.
+     *
+     * Used with std::set.
+     */
     class LMOCompare
     {
     public:
         template <typename T>
         bool operator()(const T& a, const T& b) const
         {
+            static_assert(std::is_base_of<LogicModelObjectBase, T>::value, "T must inherit from LogicModelObjectBase.");
+
             return a.get_object_id() < b.get_object_id();
         }
+
         template <typename T>
         bool operator()(const std::shared_ptr<T>& a, const std::shared_ptr<T>& b) const
         {
+            static_assert(std::is_base_of<LogicModelObjectBase, T>::value, "T must inherit from LogicModelObjectBase.");
+
             return this->operator()(*a, *b);
         }
     };

--- a/src/Core/LogicModel/LogicModelObjectBase.h
+++ b/src/Core/LogicModel/LogicModelObjectBase.h
@@ -141,8 +141,16 @@ namespace degate
     class LMOCompare
     {
     public:
-        bool operator()(const LogicModelObjectBase& a, const LogicModelObjectBase& b) const;
-        bool operator()(const LogicModelObjectBase_shptr& a, const LogicModelObjectBase_shptr& b) const;
+        template <typename T>
+        bool operator()(const T& a, const T& b) const
+        {
+            return a.get_object_id() < b.get_object_id();
+        }
+        template <typename T>
+        bool operator()(const std::shared_ptr<T>& a, const std::shared_ptr<T>& b) const
+        {
+            return this->operator()(*a, *b);
+        }
     };
 }
 


### PR DESCRIPTION
* Due to GCC 8.x.y compiler static assertion fail (fixes #6)

## Description

Fixes issue #6

## Affected area(s)

- [x] Core
- [ ] GUI
- [ ] Tests

## Changes type

- [x] Bug fix
- [ ] Migration
- [ ] New feature
- [ ] Feature rework 

## Proposed changes
