### PR TITLE
Try to repair/investigate #9 results

### DIFF
--- a/src/Core/Generator/VerilogCodeTemplateGenerator.h
+++ b/src/Core/Generator/VerilogCodeTemplateGenerator.h
@@ -56,7 +56,7 @@ namespace degate
         virtual std::string generate_port_definition() const;
 
         virtual std::string generate_module(std::string const& entity_name,
-                                            std::string const& port_description = "") const;
+                                            std::string const& port_description) const;
 
 
         virtual std::string generate_impl(std::string const& logic_class = "") const;

--- a/src/Core/Image/TileCache.h
+++ b/src/Core/Image/TileCache.h
@@ -324,7 +324,9 @@ namespace degate
                   unsigned int min_cache_tiles = 4) :
             directory(directory),
             tile_width_exp(tile_width_exp),
-            persistent(persistent)
+            persistent(persistent),
+            curr_tile_num_x(0),
+            curr_tile_num_y(0)
         {
         }
 


### PR DESCRIPTION
## Description

Try to repair/investigate results from the checks by the PVS-Studio Static Code Analyzer (#9).

## Affected area(s)

- [x] Core
- [x] GUI
- [ ] Tests

## Changes type

- [x] Bug fix
- [ ] Migration
- [ ] New feature
- [ ] Feature rework 

## Proposed changes

<details>
  <summary>Click to expand</summary>

  ```
  ===============General Analysis (GA)===============
[x]  G:\personal_projects\Degate\src\Core\Generator\VerilogTBCodeTemplateGenerator.h (50): error V762: [CWE-670] It is possible a virtual function was overridden incorrectly. See second argument of function 'generate_module' in derived class 'VerilogTBCodeTemplateGenerator' and base class 'VerilogCodeTemplateGenerator'.
[x]  G:\personal_projects\Degate\src\Core\Image\TileCache.h (321): error V730: [CWE-457] Not all members of a class are initialized inside the constructor. Consider inspecting: curr_tile_num_x, curr_tile_num_y.
  G:\personal_projects\Degate\src\Core\LogicModel\PlacedLogicModelObject.cc (34): error V730: [CWE-457] Not all members of a class are initialized inside the constructor. Consider inspecting: index.
  G:\personal_projects\Degate\src\Core\Matching\TemplateMatching.cc (48): error V730: [CWE-457] Not all members of a class are initialized inside the constructor. Consider inspecting: stats, start, finish.
  G:\personal_projects\Degate\src\Core\Primitive\RegionList.h (215): error V654: [CWE-834] The condition 'chk > 9' of loop is always false.
  G:\personal_projects\Degate\src\Core\Primitive\RegionList.h (68): error V614: [CWE-457] Uninitialized variable 'cnt' used.
  G:\personal_projects\Degate\src\Core\Utils\MemoryMap.h (341): error V614: [CWE-457] Uninitialized variable 'x' used. Consider checking the first actual argument of the 'get_void_ptr' function.
  G:\personal_projects\Degate\src\Core\Utils\ProgressControl.h (120): error V1053: Calling the 'reset_progress' virtual function in the constructor may lead to unexpected result at runtime.
  G:\personal_projects\Degate\src\GUI\Dialog\AboutDialog.cc (39): error V501: [CWE-571] There are identical sub-expressions to the left and to the right of the '==' operator: QString("nightly") == QString("nightly")
  G:\personal_projects\Degate\src\GUI\Dialog\AboutDialog.cc (43): error V501: [CWE-571] There are identical sub-expressions 'QString("unreleased")' to the left and to the right of the '==' operator.
  G:\personal_projects\Degate\src\GUI\Utils\Updater.cc (34): error V730: [CWE-457] Not all members of a class are initialized inside the constructor. Consider inspecting: notify_no_update.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (182): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (80): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (190): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (78): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (72): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (61): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (59): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (33): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (34): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (52): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (43): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (81): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (87): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (94): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (189): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (183): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (184): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (176): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (185): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (175): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (170): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (166): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (162): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (155): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (153): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (146): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (138): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (129): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (122): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (119): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (116): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (113): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (106): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (100): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (186): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (187): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (177): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (41): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\GateLibraryExporterTests.cc (49): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\GateLibraryExporterTests.cc (46): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\GateLibraryExporterTests.cc (59): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\GateLibraryImporterTests.cc (60): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\GateLibraryImporterTests.cc (59): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\GateLibraryImporterTests.cc (43): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\GateLibraryImporterTests.cc (47): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\GateLibraryImporterTests.cc (54): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\GateLibraryImporterTests.cc (58): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\GateLibraryImporterTests.cc (57): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\GateLibraryImporterTests.cc (72): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\GateLibraryImporterTests.cc (66): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\GateLibraryImporterTests.cc (69): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\GateLibraryImporterTests.cc (67): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ImageProcessingTests.cc (64): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ImageProcessingTests.cc (56): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ImageProcessingTests.cc (60): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ImageTests.cc (62): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ImageTests.cc (57): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ImageTests.cc (56): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ImageTests.cc (64): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ImageTests.cc (76): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ImageTests.cc (88): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ImageTests.cc (91): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ImageTests.cc (55): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ImageTests.cc (104): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ImageTests.cc (63): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ImageTests.cc (140): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ImageTests.cc (152): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ImageTests.cc (149): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ImageTests.cc (107): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ImageTests.cc (54): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ImageTests.cc (114): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ImageTests.cc (115): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ImageTests.cc (125): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ImageTests.cc (128): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ImageTests.cc (130): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ImageTests.cc (146): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ImageTests.cc (134): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ImageTests.cc (143): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ImageTests.cc (43): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ImageTests.cc (155): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ImageTests.cc (41): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ImageTests.cc (40): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ImageTests.cc (42): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\LogicModelDOTExporterTests.cc (45): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\LogicModelDOTExporterTests.cc (55): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\LogicModelDOTExporterTests.cc (73): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\LogicModelDOTExporterTests.cc (88): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\LogicModelImporterTests.cc (55): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\LogicModelImporterTests.cc (60): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\LogicModelImporterTests.cc (54): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\LogicModelImporterTests.cc (38): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\LogicModelImporterTests.cc (46): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\LogicModelImporterTests.cc (53): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\LogicModelImporterTests.cc (52): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\LogicModelTests.cc (48): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\LogicModelTests.cc (37): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\LogicModelTests.cc (51): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\LogicModelTests.cc (54): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\LogicModelTests.cc (76): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\LogicModelTests.cc (79): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\LogicModelTests.cc (81): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\LogicModelTests.cc (83): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\LogicModelTests.cc (34): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\LogicModelTests.cc (40): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\LogicModelTests.cc (86): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\LogicModelTests.cc (125): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\LogicModelTests.cc (129): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\LogicModelTests.cc (96): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\LogicModelTests.cc (98): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\LogicModelTests.cc (99): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\LogicModelTests.cc (102): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\LogicModelTests.cc (106): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\LogicModelTests.cc (109): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\LogicModelTests.cc (124): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\LogicModelTests.cc (126): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\LogicModelTests.cc (94): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\MemoryMapTests.cc (54): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\MemoryMapTests.cc (51): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\MemoryMapTests.cc (50): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\MemoryMapTests.cc (38): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\MemoryMapTests.cc (35): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\MemoryMapTests.cc (34): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\MemoryMapTests.cc (48): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\MemoryMapTests.cc (67): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\MemoryMapTests.cc (59): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\MemoryMapTests.cc (73): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\MemoryMapTests.cc (75): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\MemoryMapTests.cc (76): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\MemoryMapTests.cc (79): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\MemoryMapTests.cc (82): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\MemoryMapTests.cc (83): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\MemoryMapTests.cc (71): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ProjectExporterTests.cc (42): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ProjectImporterTests.cc (61): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ProjectImporterTests.cc (65): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ProjectImporterTests.cc (56): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ProjectImporterTests.cc (79): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ProjectImporterTests.cc (82): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ProjectImporterTests.cc (85): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ProjectImporterTests.cc (90): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ProjectImporterTests.cc (96): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ProjectImporterTests.cc (46): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ProjectImporterTests.cc (43): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ProjectImporterTests.cc (98): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ProjectImporterTests.cc (113): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ProjectImporterTests.cc (40): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ProjectImporterTests.cc (68): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ProjectImporterTests.cc (114): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (148): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (151): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (57): error V501: [CWE-571] There are identical sub-expressions 'qt.region_iter_begin(0, 0, 0, 0)' to the left and to the right of the '==' operator.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (49): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (150): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (48): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (45): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (105): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (147): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (44): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (41): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (121): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (108): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (143): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (117): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (119): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (118): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (141): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (140): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (137): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (136): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (135): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (120): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (133): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (146): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (177): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (174): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (86): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (93): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (84): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (81): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (94): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (78): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (57): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (72): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (69): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (99): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (75): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (63): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (58): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (104): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (66): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (59): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (122): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (60): error V501: [CWE-571] There are identical sub-expressions 'qt.region_iter_end()' to the left and to the right of the '==' operator.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (60): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ScalingManagerTests.cc (39): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ScalingManagerTests.cc (49): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (80): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (74): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (73): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (71): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (79): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (70): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (81): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (75): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (87): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (88): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (103): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (90): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (62): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (91): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (92): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (93): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (97): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (98): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (100): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (84): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (58): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (102): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (50): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (49): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (105): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (45): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (43): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (42): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (41): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (39): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (106): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (108): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (57): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (101): error V521: [CWE-480] Such expressions using the ',' operator are dangerous. Make sure the expression is correct.
  G:\personal_projects\Degate\src\Core\Generator\CodeTemplateGenerator.cc (138): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\Generator\CodeTemplateGenerator.cc (149): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\Generator\CodeTemplateGenerator.cc (160): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\Generator\CodeTemplateGenerator.h (104): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\Generator\VerilogCodeTemplateGenerator.cc (407): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\Generator\VerilogCodeTemplateGenerator.cc (194): error V560: [CWE-571] A part of conditional expression is always true: in.size() > 0.
  G:\personal_projects\Degate\src\Core\Generator\VerilogCodeTemplateGenerator.cc (139): error V547: [CWE-570] Expression 'reset_name.empty()' is always false.
  G:\personal_projects\Degate\src\Core\Generator\VerilogCodeTemplateGenerator.cc (194): error V560: [CWE-571] A part of conditional expression is always true: out.size() > 0.
  G:\personal_projects\Degate\src\Core\Generator\VerilogCodeTemplateGenerator.cc (126): error V688: The 'logic_class' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Generator\VerilogCodeTemplateGenerator.cc (112): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\Generator\VerilogCodeTemplateGenerator.cc (332): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\Generator\VerilogCodeTemplateGenerator.cc (102): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\Generator\VerilogModuleGenerator.cc (172): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\Generator\VerilogTBCodeTemplateGenerator.cc (49): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\Generator\VerilogTBCodeTemplateGenerator.cc (208): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\Generator\VerilogTBCodeTemplateGenerator.cc (198): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\Generator\VerilogTBCodeTemplateGenerator.cc (82): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\Generator\VerilogTBCodeTemplateGenerator.cc (91): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\Generator\VerilogTBCodeTemplateGenerator.cc (51): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\Generator\VHDLCodeTemplateGenerator.cc (215): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\Generator\VHDLCodeTemplateGenerator.cc (238): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\Generator\VHDLTBCodeTemplateGenerator.cc (51): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\Generator\VHDLTBCodeTemplateGenerator.cc (52): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\Image\Manipulation\MorphologicalFilter.h (249): error V519: [CWE-563] The 'running' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 248, 249.
  G:\personal_projects\Degate\src\Core\Image\Processor\IPCopy.h (46): error V730: [CWE-457] Not all members of a class are initialized inside the constructor. Consider inspecting: min_x, max_x, min_y, max_y.
  G:\personal_projects\Degate\src\Core\LogicModel\Annotation\Annotation.h (100): error V730: [CWE-457] Not all members of a class are initialized inside the constructor. Consider inspecting: class_id.
  G:\personal_projects\Degate\src\Core\LogicModel\Gate\AutoNameGates.cc (63): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\LogicModel\Gate\AutoNameGates.cc (90): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\LogicModel\Gate\GateLibraryImporter.cc (233): error V1024: [CWE-20] The 'myfile' stream is checked for EOF before reading from it, but is not checked after reading. Potential use of invalid data.
  G:\personal_projects\Degate\src\Core\LogicModel\Gate\GatePort.h (57): error V730: [CWE-457] Not all members of a class are initialized inside the constructor. Consider inspecting: template_port_id.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModel.cc (751): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModel.cc (730): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModelHelper.cc (850): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModelHelper.cc (832): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModelHelper.cc (818): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModelHelper.cc (777): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModelImporter.cc (551): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModelImporter.cc (80): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\LogicModel\Via\Via.h (70): error V730: [CWE-457] Not all members of a class are initialized inside the constructor. Consider inspecting: direction.
  G:\personal_projects\Degate\src\Core\Matching\EdgeDetection.cc (137): error V581: [CWE-670] The conditional expressions of the 'if' statements situated alongside each other are identical. Check lines: 136, 137.
  G:\personal_projects\Degate\src\Core\Matching\ExternalMatching.cc (36): error V730: [CWE-457] Not all members of a class are initialized inside the constructor. Consider inspecting: exit_code.
  G:\personal_projects\Degate\src\Core\Matching\ExternalMatching.cc (106): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\Matching\LineSegmentExtraction.h (279): error V1048: [CWE-1164] The 'running' variable was assigned the same value.
  G:\personal_projects\Degate\src\Core\Matching\LineSegmentExtraction.h (292): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\Matching\TemplateMatching.cc (305): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\Matching\TemplateMatching.cc (260): error V688: The 'matches' local variable possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Matching\ViaMatching.cc (35): error V730: [CWE-457] Not all members of a class are initialized inside the constructor. Consider inspecting: via_diameter, merge_n_vias.
  G:\personal_projects\Degate\src\Core\Matching\ViaMatching.cc (296): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\Matching\WireMatching.cc (112): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\Primitive\QuadTree.h (430): error V1048: [CWE-1164] The 'ret' variable was assigned the same value.
  G:\personal_projects\Degate\src\Core\Primitive\QuadTreeDownIterator.h (30): error V690: The 'DownIterator' class implements the copy assignment operator, but lacks a copy constructor. It is dangerous to use such a class.
  G:\personal_projects\Degate\src\Core\Primitive\QuadTreeRegionIterator.h (32): error V690: The 'RegionIterator' class implements the copy assignment operator, but lacks a copy constructor. It is dangerous to use such a class.
  G:\personal_projects\Degate\src\Core\Primitive\Region.h (486): error V730: [CWE-457] Not all members of a class are initialized inside the constructor. Consider inspecting: y_min, y_max, x_min, x_max.
  G:\personal_projects\Degate\src\Core\Primitive\RegionList.h (287): error V730: [CWE-457] Not all members of a class are initialized inside the constructor. Consider inspecting: width, height, count.
  G:\personal_projects\Degate\src\Core\Project\Project.cc (50): error V730: [CWE-457] It is possible that not all members of a class are initialized inside the constructor. Consider inspecting: changed.
  G:\personal_projects\Degate\src\Core\Project\Project.cc (40): error V730: [CWE-457] It is possible that not all members of a class are initialized inside the constructor. Consider inspecting: changed.
  G:\personal_projects\Degate\src\Core\Project\ProjectImporter.cc (266): error V668: [CWE-570] There is no sense in testing the 'new_bg_image' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error.
  G:\personal_projects\Degate\src\Core\RuleCheck\RCVBlacklistExporter.cc (50): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\RuleCheck\RuleChecker.h (56): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\RuleCheck\RuleChecker.h (53): error V1044: [CWE-834] Loop break conditions do not depend on the number of iterations.
  G:\personal_projects\Degate\src\Core\Utils\MemoryMap.h (332): error V751: Parameter 'min_x' is not used inside function body.
  G:\personal_projects\Degate\src\Core\Utils\ProgressControl.h (118): error V730: [CWE-457] It is possible that not all members of a class are initialized inside the constructor. Consider inspecting: step_size.
  G:\personal_projects\Degate\src\GUI\Widget\LayersEditWidget.cc (451): error V522: [CWE-690] There might be dereferencing of a potential null pointer.
  G:\personal_projects\Degate\src\GUI\Widget\LayersEditWidget.cc (366): error V522: [CWE-690] There might be dereferencing of a potential null pointer 'background'.
  G:\personal_projects\Degate\src\GUI\Widget\LayersEditWidget.cc (359): error V522: [CWE-690] There might be dereferencing of a potential null pointer.
  G:\personal_projects\Degate\src\GUI\Widget\LayersEditWidget.cc (458): error V522: [CWE-690] There might be dereferencing of a potential null pointer.
  G:\personal_projects\Degate\src\GUI\Widget\LayersEditWidget.cc (256): error V522: [CWE-690] There might be dereferencing of a potential null pointer 'background'.
  G:\personal_projects\Degate\src\GUI\Widget\LayersEditWidget.cc (459): error V522: [CWE-690] There might be dereferencing of a potential null pointer.
  G:\personal_projects\Degate\src\GUI\Widget\LayersEditWidget.cc (494): error V522: [CWE-690] There might be dereferencing of a potential null pointer.
  G:\personal_projects\Degate\src\GUI\Widget\LayersEditWidget.cc (452): error V522: [CWE-690] There might be dereferencing of a potential null pointer.
  G:\personal_projects\Degate\src\GUI\Widget\LayersEditWidget.cc (495): error V522: [CWE-690] There might be dereferencing of a potential null pointer.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (148): error V522: [CWE-690] There might be dereferencing of a potential null pointer 'w2'.
  G:\personal_projects\Degate\src\Core\DOT\LogicModelDOTExporter.h (147): error V783: [CWE-119] Dereferencing of the invalid iterator 'found' might take place.
  G:\personal_projects\Degate\src\Core\Generator\VerilogCodeTemplateGenerator.cc (75): error V688: The 'entity_name' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Generator\VHDLCodeTemplateGenerator.cc (99): error V688: The 'logic_class' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Generator\VHDLCodeTemplateGenerator.cc (194): error V688: The 'entity_name' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Generator\VHDLCodeTemplateGenerator.cc (88): error V688: The 'entity_name' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Generator\VHDLCodeTemplateGenerator.cc (76): error V688: The 'entity_name' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Grid\IrregularGrid.cc (42): error V547: [CWE-571] Expression 'current >= pos' is always true.
  G:\personal_projects\Degate\src\Core\Grid\RegularGrid.cc (34): error V1034: [CWE-834] Do not use real type variables as loop counters.
  G:\personal_projects\Degate\src\Core\Grid\RegularGrid.cc (54): error V550: [CWE-682] An odd precise comparison: distance == 0. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  G:\personal_projects\Degate\src\Core\Grid\RegularGrid.h (69): error V688: The 'max' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Grid\RegularGrid.h (69): error V688: The 'min' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Image\Image.h (27): error V1003: The macro 'MASK_R' is a dangerous expression. The parameter 'r' must be surrounded by parentheses.
  G:\personal_projects\Degate\src\Core\Image\Image.h (35): error V1003: The macro 'MASK_B' is a dangerous expression. The parameter 'b' must be surrounded by parentheses.
  G:\personal_projects\Degate\src\Core\Image\Image.h (29): error V1003: The macro 'MASK_B' is a dangerous expression. The parameter 'b' must be surrounded by parentheses.
  G:\personal_projects\Degate\src\Core\Image\Image.h (28): error V1003: The macro 'MASK_G' is a dangerous expression. The parameter 'g' must be surrounded by parentheses.
  G:\personal_projects\Degate\src\Core\Image\Image.h (30): error V1003: The macro 'MASK_A' is a dangerous expression. The parameter 'a' must be surrounded by parentheses.
  G:\personal_projects\Degate\src\Core\Image\Image.h (31): error V1003: The macro 'MERGE_CHANNELS' is a dangerous expression. The parameters 'r', 'g', 'b', 'a' must be surrounded by parentheses.
  G:\personal_projects\Degate\src\Core\Image\Image.h (33): error V1003: The macro 'MASK_R' is a dangerous expression. The parameter 'r' must be surrounded by parentheses.
  G:\personal_projects\Degate\src\Core\Image\Image.h (34): error V1003: The macro 'MASK_G' is a dangerous expression. The parameter 'g' must be surrounded by parentheses.
  G:\personal_projects\Degate\src\Core\Image\Image.h (37): error V1003: The macro 'MERGE_CHANNELS' is a dangerous expression. The parameters 'r', 'g', 'b', 'a' must be surrounded by parentheses.
  G:\personal_projects\Degate\src\Core\Image\Image.h (36): error V1003: The macro 'MASK_A' is a dangerous expression. The parameter 'a' must be surrounded by parentheses.
  G:\personal_projects\Degate\src\Core\Image\ImageHelper.h (155): error V614: [CWE-457] The 'new_img' smart pointer is utilized immediately after being declared or reset. It is suspicious that no value was assigned to it.
  G:\personal_projects\Degate\src\Core\Image\Manipulation\ImageManipulation.h (629): error V537: [CWE-682] Consider reviewing the correctness of 'kernel_width' item's usage.
  G:\personal_projects\Degate\src\Core\Image\Manipulation\ImageManipulation.h (162): error V636: [CWE-682] The '147 * ((p >> 8) & 0xff)' expression was implicitly cast from 'int' type to 'double' type. Consider utilizing an explicit type cast to avoid overflow. An example: double A = (double)(X) * Y;.
  G:\personal_projects\Degate\src\Core\Image\Manipulation\ImageManipulation.h (119): error V550: [CWE-682] An odd precise comparison: max == 0. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  G:\personal_projects\Degate\src\Core\Image\Manipulation\ScalingManager.h (194): error V783: [CWE-119] Dereferencing of the invalid iterator 'found' might take place.
  G:\personal_projects\Degate\src\Core\Image\TileCache.h (416): error V576: [CWE-628] Incorrect format. Consider checking the fourth actual argument of the 'snprintf' function. The SIGNED integer type argument is expected.
  G:\personal_projects\Degate\src\Core\Image\TileCache.h (416): error V576: [CWE-628] Incorrect format. Consider checking the fifth actual argument of the 'snprintf' function. The SIGNED integer type argument is expected.
  G:\personal_projects\Degate\src\Core\Image\TileImage.h (76): error V688: The 'tile_width_exp' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\LogicModel\Gate\AutoNameGates.cc (117): error V688: The 'lmodel' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\LogicModel\Gate\Gate.cc (139): error V688: The 'gate_template' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\LogicModel\Gate\Gate.cc (155): error V550: [CWE-682] An odd precise comparison. It's probably better to use a comparison with defined precision: fabs(A - B) > Epsilon.
  G:\personal_projects\Degate\src\Core\LogicModel\Gate\Gate.cc (154): error V550: [CWE-682] An odd precise comparison. It's probably better to use a comparison with defined precision: fabs(A - B) > Epsilon.
  G:\personal_projects\Degate\src\Core\LogicModel\Gate\GateLibraryImporter.cc (133): error V550: [CWE-682] An odd precise comparison: max_x == 0. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  G:\personal_projects\Degate\src\Core\LogicModel\Gate\GateLibraryImporter.cc (133): error V550: [CWE-682] An odd precise comparison: min_y == 0. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  G:\personal_projects\Degate\src\Core\LogicModel\Gate\GateLibraryImporter.cc (133): error V550: [CWE-682] An odd precise comparison: min_x == 0. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  G:\personal_projects\Degate\src\Core\LogicModel\Gate\GateLibraryImporter.cc (133): error V550: [CWE-682] An odd precise comparison: max_y == 0. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  G:\personal_projects\Degate\src\Core\LogicModel\Gate\GatePort.cc (104): error V688: The 'gate_template_port' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\LogicModel\Layer.cc (155): error V688: The 'layer_type' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModel.cc (114): error V688: The 'layers' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModel.cc (705): error V688: The 'layers' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModel.cc (89): error V688: The 'layers' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModel.cc (923): error V688: The 'main_module' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModelHelper.cc (245): error V537: [CWE-682] Consider reviewing the correctness of 'tile_count_x' item's usage.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModelHelper.cc (253): error V576: [CWE-628] Incorrect format. Consider checking the fourth actual argument of the 'snprintf' function. The SIGNED integer type argument is expected.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModelHelper.cc (253): error V576: [CWE-628] Incorrect format. Consider checking the fifth actual argument of the 'snprintf' function. The SIGNED integer type argument is expected.
  G:\personal_projects\Degate\src\Core\Matching\BinaryLineDetection.cc (67): error V688: The 'directory' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Matching\BinaryLineDetection.cc (210): error V636: [CWE-682] The expression was implicitly cast from 'int' type to 'double' type. Consider utilizing an explicit type cast to avoid overflow. An example: double A = (double)(X) * Y;.
  G:\personal_projects\Degate\src\Core\Matching\BinaryLineDetection.cc (230): error V688: The 'region' local variable possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Matching\BinaryLineDetection.cc (200): error V688: The 'mean_image' local variable possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Matching\ExternalMatching.cc (143): error V614: [CWE-457] The 'plo' smart pointer is utilized immediately after being declared or reset. It is suspicious that no value was assigned to it.
  G:\personal_projects\Degate\src\Core\Matching\LineSegmentExtraction.h (368): error V688: The 'img' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Matching\LineSegmentExtraction.h (403): error V614: [CWE-457] The 'segment' smart pointer is utilized immediately after being declared or reset. It is suspicious that no value was assigned to it.
  G:\personal_projects\Degate\src\Core\Matching\TemplateMatching.cc (120): error V688: The 'scale_down' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Matching\TemplateMatching.cc (96): error V688: The 'bounding_box' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Matching\TemplateMatching.cc (771): error V656: [CWE-665] Variables 'state->iter_begin', 'state->iter_last' are initialized through the call to the same function. It's probably an error or un-optimized code. Consider inspecting the 'state->grid->begin()' expression. Check lines: 770, 771.
  G:\personal_projects\Degate\src\Core\Matching\TemplateMatching.cc (661): error V550: [CWE-682] An odd precise comparison: denominator == 0. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  G:\personal_projects\Degate\src\Core\Matching\TemplateMatching.cc (628): error V636: [CWE-682] The expression was implicitly cast from 'int' type to 'double' type. Consider utilizing an explicit type cast to avoid overflow. An example: double A = (double)(X) * Y;.
  G:\personal_projects\Degate\src\Core\Matching\TemplateMatching.cc (96): error V688: The 'project' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Matching\TemplateMatching.cc (119): error V688: The 'bounding_box' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Matching\TemplateMatching.cc (484): error V688: The 'matches' local variable possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Matching\TemplateMatching.cc (129): error V688: The 'bounding_box' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Matching\TemplateMatching.cc (448): error V688: The 'threshold_hc' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Matching\TemplateMatching.cc (210): error V688: The 'gs_img_scaled' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Matching\TemplateMatching.cc (245): error V688: The 'tmpl_orientations' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Matching\TemplateMatching.cc (433): error V688: The 'threshold_hc' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Matching\TemplateMatching.cc (475): error V688: The 'threshold_hc' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Matching\TemplateMatching.cc (475): error V688: The 'threshold_detection' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Matching\TemplateMatching.cc (209): error V688: The 'gs_img_normal' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Matching\ViaMatching.cc (129): error V688: The 'img' local variable possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Matching\ZeroCrossingEdgeDetection.cc (186): error V688: The 'min_d' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Matching\ZeroCrossingEdgeDetection.cc (97): error V688: The 'max_d' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Matching\ZeroCrossingEdgeDetection.cc (186): error V688: The 'max_d' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Matching\ZeroCrossingEdgeDetection.cc (97): error V688: The 'min_d' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Matching\ZeroCrossingEdgeDetection.cc (96): error V688: The 'zero_threshold' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Matching\ZeroCrossingEdgeDetection.cc (95): error V688: The 'edge_threshold' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Primitive\BoundingBox.cc (202): error V688: The 'min_y' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Primitive\BoundingBox.cc (202): error V688: The 'max_y' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Primitive\BoundingBox.cc (36): error V688: The 'max_y' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Primitive\BoundingBox.cc (36): error V688: The 'min_y' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Primitive\BoundingBox.cc (202): error V688: The 'min_x' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Primitive\BoundingBox.cc (150): error V688: The 'min_x' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Primitive\BoundingBox.cc (36): error V688: The 'max_x' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Primitive\BoundingBox.cc (168): error V688: The 'max_y' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Primitive\BoundingBox.cc (202): error V688: The 'max_x' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Primitive\BoundingBox.cc (162): error V688: The 'max_x' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Primitive\BoundingBox.cc (156): error V688: The 'min_y' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Primitive\BoundingBox.cc (36): error V688: The 'min_x' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Primitive\BoundingBox.cc (80): error V550: [CWE-682] An odd precise comparison: max_x == other.max_x. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  G:\personal_projects\Degate\src\Core\Primitive\BoundingBox.cc (81): error V550: [CWE-682] An odd precise comparison: min_y == other.min_y. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  G:\personal_projects\Degate\src\Core\Primitive\BoundingBox.cc (82): error V550: [CWE-682] An odd precise comparison: max_y == other.max_y. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  G:\personal_projects\Degate\src\Core\Primitive\BoundingBox.cc (79): error V550: [CWE-682] An odd precise comparison: min_x == other.min_x. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  G:\personal_projects\Degate\src\Core\Primitive\BoundingBox.h (31): error V690: The 'BoundingBox' class implements a copy constructor, but lacks the copy assignment operator. It is dangerous to use such a class.
  G:\personal_projects\Degate\src\Core\Primitive\Circle.cc (77): error V550: [CWE-682] An odd precise comparison: x == other.x. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  G:\personal_projects\Degate\src\Core\Primitive\Circle.cc (77): error V550: [CWE-682] An odd precise comparison: y == other.y. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  G:\personal_projects\Degate\src\Core\Primitive\Line.cc (214): error V688: The 'to_y' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Primitive\Line.cc (89): error V550: [CWE-682] An odd precise comparison: from_y == to_y. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  G:\personal_projects\Degate\src\Core\Primitive\Line.cc (154): error V550: [CWE-682] An odd precise comparison: to_x - from_x == 0. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  G:\personal_projects\Degate\src\Core\Primitive\Line.cc (159): error V550: [CWE-682] An odd precise comparison: to_y - from_y == 0. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  G:\personal_projects\Degate\src\Core\Primitive\Line.cc (193): error V688: The 'from_x' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Primitive\Line.cc (200): error V688: The 'to_x' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Primitive\Line.cc (207): error V688: The 'from_y' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Primitive\Line.cc (89): error V550: [CWE-682] An odd precise comparison: from_x == to_x. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  G:\personal_projects\Degate\src\Core\Primitive\Point.cc (45): error V550: [CWE-682] An odd precise comparison: x == other.x. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  G:\personal_projects\Degate\src\Core\Primitive\Point.cc (45): error V550: [CWE-682] An odd precise comparison: y == other.y. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  G:\personal_projects\Degate\src\Core\Primitive\QuadTree.h (476): error V688: The 'box' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Primitive\QuadTree.h (261): error V688: The 'parent' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Primitive\QuadTreeDownIterator.h (66): error V688: The 'node' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Primitive\QuadTreeRegionIterator.h (77): error V688: The 'node' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Primitive\Rectangle.cc (41): error V688: The 'max_x' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Primitive\Rectangle.cc (216): error V688: The 'max_y' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Primitive\Rectangle.cc (216): error V688: The 'min_y' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Primitive\Rectangle.cc (216): error V688: The 'max_x' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Primitive\Rectangle.cc (216): error V688: The 'min_x' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Primitive\Rectangle.cc (41): error V688: The 'min_x' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Primitive\Rectangle.cc (184): error V688: The 'max_y' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Primitive\Rectangle.cc (177): error V688: The 'max_x' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Primitive\Rectangle.cc (41): error V688: The 'min_y' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Primitive\Rectangle.cc (41): error V688: The 'max_y' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Primitive\Rectangle.cc (89): error V550: [CWE-682] An odd precise comparison: min_x == other.min_x. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  G:\personal_projects\Degate\src\Core\Primitive\Rectangle.cc (90): error V550: [CWE-682] An odd precise comparison: max_x == other.max_x. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  G:\personal_projects\Degate\src\Core\Primitive\Rectangle.cc (91): error V550: [CWE-682] An odd precise comparison: min_y == other.min_y. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  G:\personal_projects\Degate\src\Core\Primitive\Rectangle.cc (92): error V550: [CWE-682] An odd precise comparison: max_y == other.max_y. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  G:\personal_projects\Degate\src\Core\Primitive\Rectangle.cc (163): error V688: The 'min_x' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Primitive\Rectangle.cc (170): error V688: The 'min_y' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Primitive\Rectangle.h (32): error V690: The 'Rectangle' class implements a copy constructor, but lacks the copy assignment operator. It is dangerous to use such a class.
  G:\personal_projects\Degate\src\Core\Primitive\RegionList.h (220): error V576: [CWE-628] Incorrect format. Consider checking the third actual argument of the 'sprintf' function. The SIGNED integer type argument is expected.
  G:\personal_projects\Degate\src\Core\Project\ProjectImporter.cc (96): error V550: [CWE-682] An odd precise comparison: bbox.get_min_y() != 0. It's probably better to use a comparison with defined precision: fabs(A - B) > Epsilon.
  G:\personal_projects\Degate\src\Core\Project\ProjectImporter.cc (96): error V550: [CWE-682] An odd precise comparison: bbox.get_min_x() != 0. It's probably better to use a comparison with defined precision: fabs(A - B) > Epsilon.
  G:\personal_projects\Degate\src\Core\Project\ProjectImporter.cc (97): error V550: [CWE-682] An odd precise comparison: bbox.get_max_x() != 0. It's probably better to use a comparison with defined precision: fabs(A - B) > Epsilon.
  G:\personal_projects\Degate\src\Core\Project\ProjectImporter.cc (97): error V550: [CWE-682] An odd precise comparison: bbox.get_max_y() != 0. It's probably better to use a comparison with defined precision: fabs(A - B) > Epsilon.
  G:\personal_projects\Degate\src\Core\Utils\DegateHelper.h (28): error V1003: The macro 'LENGTH_TO_MAX' is a dangerous expression. The parameter 'l' must be surrounded by parentheses.
  G:\personal_projects\Degate\src\Core\Utils\FilterKernel.h (120): error V525: [CWE-682] The code contains the collection of similar blocks. Check items '1', '2', '1' in lines 120, 121, 122.
  G:\personal_projects\Degate\src\Core\Utils\MemoryMap.h (333): error V688: The 'width' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Utils\MemoryMap.h (333): error V688: The 'height' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Utils\MemoryMap.h (350): error V688: The 'filename' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\Core\Utils\Otsu.cc (58): error V636: [CWE-682] The 't * hist_data[t]' expression was implicitly cast from 'int' type to 'double' type. Consider utilizing an explicit type cast to avoid overflow. An example: double A = (double)(X) * Y;.
  G:\personal_projects\Degate\src\GUI\Dialog\ColorPickerDialog.cc (151): error V688: The 'color' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\GUI\Dialog\ColorPickerDialog.cc (117): error V688: The 'color' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\GUI\Dialog\ColorPickerDialog.cc (128): error V688: The 'color' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\GUI\Dialog\ProgressDialog.cc (58): error V688: The 'job' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\GUI\Dialog\TemplateMatchingDialog.cc (183): error V522: [CWE-690] There might be dereferencing of a potential null pointer 'matching'.
  G:\personal_projects\Degate\src\GUI\Dialog\TemplateMatchingDialog.cc (225): error V522: [CWE-690] There might be dereferencing of a potential null pointer 'matching'.
  G:\personal_projects\Degate\src\GUI\MainWindow.cc (36): error V1003: The macro 'SECOND' is a dangerous expression. The expression must be surrounded by parentheses.
  G:\personal_projects\Degate\src\GUI\Preferences\ThemeManager.cc (229): error V523: [CWE-691] The 'then' statement is equivalent to the 'else' statement.
  G:\personal_projects\Degate\src\GUI\Text\DistanceFieldGenerator.cc (27): error V1003: The macro 'SQUARE_DISTANCE' is a dangerous expression. The parameters 'x1', 'y1', 'x2', 'y2' must be surrounded by parentheses.
  G:\personal_projects\Degate\src\GUI\Widget\DoubleSliderWidget.cc (53): error V688: The 'single_step' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\GUI\Widget\DoubleSliderWidget.cc (125): error V688: The 'value' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\GUI\Widget\DoubleSliderWidget.cc (103): error V688: The 'decimals' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\GUI\Widget\DoubleSliderWidget.cc (91): error V688: The 'value' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\src\GUI\Widget\LayersEditWidget.cc (150): error V688: The 'type' function argument possesses the same name as one of the class members, which can result in a confusion.
  G:\personal_projects\Degate\tests\src\ImageTests.cc (146): error V550: [CWE-682] An odd precise comparison. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  G:\personal_projects\Degate\tests\src\ImageTests.cc (149): error V550: [CWE-682] An odd precise comparison: 23.0 == db. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (118): error V550: [CWE-682] An odd precise comparison: w->get_from_x() == 20. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (150): error V550: [CWE-682] An odd precise comparison: w2->get_from_x() == 20. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (151): error V550: [CWE-682] An odd precise comparison: w2->get_from_y() == 21. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (121): error V550: [CWE-682] An odd precise comparison: w->get_to_y() == 31. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (119): error V550: [CWE-682] An odd precise comparison: w->get_from_y() == 21. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (120): error V550: [CWE-682] An odd precise comparison: w->get_to_x() == 30. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (88): error V550: [CWE-682] An odd precise comparison: b.get_width() == 90. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (87): error V550: [CWE-682] An odd precise comparison: b.get_height() == diameter. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (97): error V550: [CWE-682] An odd precise comparison: b.get_height() == 90. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  G:\personal_projects\Degate\tests\src\ShapeTests.cc (98): error V550: [CWE-682] An odd precise comparison: b.get_width() == diameter. It's probably better to use a comparison with defined precision: fabs(A - B) < Epsilon.
  
  ===============Optimization (OP)===============
  G:\personal_projects\Degate\src\Core\Image\ImageHelper.h (182): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Image\ImageHelper.h (136): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Image\ImageHelper.h (120): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Image\Manipulation\ImageManipulation.h (452): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Image\Manipulation\ScalingManager.h (161): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Image\Manipulation\ScalingManager.h (170): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Image\Processor\IPConvolve.h (69): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Image\Processor\IPCopy.h (87): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Image\Processor\IPImageWriter.h (68): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Image\Processor\IPMedianFilter.h (63): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Image\Processor\IPNormalize.h (71): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Image\Processor\IPThresholding.h (69): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Image\TileCache.h (534): error V824: Instantiation of TileCache < PixelPolicy >: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Image\TileCache.h (534): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\LogicModel\Gate\GateLibraryImporter.cc (93): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModel.cc (685): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModel.cc (569): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModel.cc (401): error V808: 'found' object of '_Rb_tree_iterator' type was created but was not utilized.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModelHelper.cc (222): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModelHelper.h (91): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModelHelper.h (283): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModelImporter.cc (384): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModelImporter.cc (329): error V808: 'direction_str' object of 'basic_string' type was created but was not utilized.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModelImporter.cc (503): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModelImporter.cc (332): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModelImporter.cc (290): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModelImporter.cc (239): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModelImporter.cc (150): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModelImporter.cc (94): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Matching\BinaryLineDetection.cc (119): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Matching\BinaryLineDetection.cc (125): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Matching\BinaryLineDetection.cc (230): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Matching\BinaryLineDetection.cc (135): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Matching\BinaryLineDetection.cc (112): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Matching\BinaryLineDetection.cc (132): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Matching\BinaryLineDetection.cc (176): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Matching\BinaryLineDetection.cc (200): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Matching\EdgeDetection.cc (82): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Matching\EdgeDetection.cc (61): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Matching\EdgeDetection.cc (68): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Matching\EdgeDetection.cc (75): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Matching\EdgeDetection.cc (85): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Matching\EdgeDetection.cc (124): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Matching\EdgeDetection.cc (129): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Matching\EdgeDetection.cc (128): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Matching\EdgeDetection.cc (155): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Matching\EdgeDetection.cc (186): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Matching\EdgeDetection.cc (125): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Matching\LineSegmentExtraction.h (360): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Matching\LineSegmentExtraction.h (378): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Matching\LineSegmentExtraction.h (393): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Matching\TemplateMatching.cc (453): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Matching\TemplateMatching.cc (356): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Matching\ViaMatching.cc (226): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Matching\WireMatching.cc (115): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Matching\ZeroCrossingEdgeDetection.cc (194): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Matching\ZeroCrossingEdgeDetection.cc (58): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Primitive\Region.h (289): error V808: 'iter_end_point' object of '_List_iterator' type was created but was not utilized.
  G:\personal_projects\Degate\src\Core\Primitive\Region.h (479): error V826: Consider replacing the 'list_x' std::list with std::vector. Contiguous placement of elements in memory can be more efficient.
  G:\personal_projects\Degate\src\Core\Primitive\Region.h (91): error V826: Consider replacing the 'list_x' std::list with std::vector. Contiguous placement of elements in memory can be more efficient.
  G:\personal_projects\Degate\src\Core\Primitive\RegionList.h (268): error V808: 'iter_end_point' object of '_List_iterator' type was created but was not utilized.
  G:\personal_projects\Degate\src\Core\Primitive\RegionList.h (218): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Primitive\RegionList.h (253): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Primitive\RegionList.h (267): error V808: 'iter_region_line' object of '_List_iterator' type was created but was not utilized.
  G:\personal_projects\Degate\src\Core\Primitive\RegionList.h (269): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Primitive\RegionList.h (166): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Primitive\RegionList.h (252): error V808: 'iter_end_point' object of '_List_iterator' type was created but was not utilized.
  G:\personal_projects\Degate\src\Core\Primitive\RegionList.h (251): error V808: 'iter_region_line' object of '_List_iterator' type was created but was not utilized.
  G:\personal_projects\Degate\src\Core\Project\ProjectExporter.cc (55): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Project\ProjectImporter.cc (146): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Project\ProjectImporter.cc (256): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\Project\ProjectImporter.cc (284): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\RuleCheck\RCVBlacklistExporter.cc (38): error V808: 'directory' object of 'basic_string' type was created but was not utilized.
  G:\personal_projects\Degate\src\Core\RuleCheck\RCVBlacklistImporter.cc (44): error V808: 'directory' object of 'basic_string' type was created but was not utilized.
  G:\personal_projects\Degate\src\Core\RuleCheck\RCVBlacklistImporter.cc (93): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\GUI\Dialog\ModulesDialog.cc (306): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (135): error V808: 'filename2' object of 'basic_string' type was created but was not utilized.
  G:\personal_projects\Degate\tests\src\ImageProcessingTests.cc (43): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\tests\src\ImageProcessingTests.cc (46): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\tests\src\ImageProcessingTests.cc (37): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\tests\src\ImageTests.cc (72): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\tests\src\LogicModelTests.cc (91): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\tests\src\LogicModelTests.cc (113): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\tests\src\LogicModelTests.cc (78): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\tests\src\LogicModelTests.cc (75): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\tests\src\LogicModelTests.cc (47): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\tests\src\LogicModelTests.cc (93): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\tests\src\LogicModelTests.cc (59): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (80): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (43): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (47): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (114): error V829: Lifetime of the heap-allocated variable 'qtree' is limited to the current function's scope. Consider allocating it on the stack instead.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (62): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (65): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (68): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (71): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (162): error V829: Lifetime of the heap-allocated variable 'qtree' is limited to the current function's scope. Consider allocating it on the stack instead.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (74): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (83): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\tests\src\QuadTreeTests.cc (77): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\tests\src\ScalingManagerTests.cc (43): error V824: It is recommended to use the 'make_shared' function to create smart pointers.
  G:\personal_projects\Degate\src\Core\DOT\DOTExporter.cc (49): error V813: Decreased performance. The 'to_node_id', 'edge_params' arguments should probably be rendered as constant references.
  G:\personal_projects\Degate\src\Core\DOT\DOTExporter.cc (31): error V813: Decreased performance. The 'header_line' argument should probably be rendered as a constant reference.
  G:\personal_projects\Degate\src\Core\DOT\DOTExporter.cc (36): error V813: Decreased performance. The 'line' argument should probably be rendered as a constant reference.
  G:\personal_projects\Degate\src\Core\DOT\DOTExporter.cc (52): error V820: The 'from_node_id' variable is not used after copying. Copying can be replaced with move/swap for optimization.
  G:\personal_projects\Degate\src\Core\DOT\DOTExporter.cc (42): error V813: Decreased performance. The 'node_id', 'node_params' arguments should probably be rendered as constant references.
  G:\personal_projects\Degate\src\Core\Generator\VerilogTBCodeTemplateGenerator.cc (87): error V823: Decreased performance. Object may be created in-place in the 'port_wiring' container. Consider replacing methods: 'push_back' -> 'emplace_back'.
  G:\personal_projects\Degate\src\Core\Generator\VHDLCodeTemplateGenerator.cc (242): error V823: Decreased performance. Object may be created in-place in the 'port_map_str' container. Consider replacing methods: 'push_back' -> 'emplace_back'.
  G:\personal_projects\Degate\src\Core\Image\Manipulation\ScalingManager.h (88): error V818: It is more efficient to use an initialization list 'base_directory(base_directory)' rather than an assignment operator.
  G:\personal_projects\Degate\src\Core\LogicModel\Gate\AutoNameGates.cc (32): error V801: Decreased performance. It is better to redefine the second function argument as a reference. Consider replacing 'const .. rhs' with 'const .. &rhs'.
  G:\personal_projects\Degate\src\Core\LogicModel\Gate\AutoNameGates.cc (37): error V801: Decreased performance. It is better to redefine the second function argument as a reference. Consider replacing 'const .. rhs' with 'const .. &rhs'.
  G:\personal_projects\Degate\src\Core\LogicModel\Gate\AutoNameGates.cc (32): error V801: Decreased performance. It is better to redefine the first function argument as a reference. Consider replacing 'const .. lhs' with 'const .. &lhs'.
  G:\personal_projects\Degate\src\Core\LogicModel\Gate\AutoNameGates.cc (37): error V801: Decreased performance. It is better to redefine the first function argument as a reference. Consider replacing 'const .. lhs' with 'const .. &lhs'.
  G:\personal_projects\Degate\src\Core\LogicModel\Gate\GateLibrary.cc (108): error V803: Decreased performance. In case 'piter' is iterator it's more effective to use prefix form of increment. Replace iterator++ with ++iterator.
  G:\personal_projects\Degate\src\Core\LogicModel\Gate\GateLibrary.cc (126): error V803: Decreased performance. In case 'piter' is iterator it's more effective to use prefix form of increment. Replace iterator++ with ++iterator.
  G:\personal_projects\Degate\src\Core\LogicModel\Gate\GateLibraryImporter.cc (194): error V801: Decreased performance. It is better to redefine the first function argument as a reference. Consider replacing 'const .. implementations_element' with 'const .. &implementations_element'.
  G:\personal_projects\Degate\src\Core\LogicModel\Gate\GateLibraryImporter.cc (166): error V801: Decreased performance. It is better to redefine the first function argument as a reference. Consider replacing 'const .. template_images_element' with 'const .. &template_images_element'.
  G:\personal_projects\Degate\src\Core\LogicModel\Gate\GateLibraryImporter.cc (255): error V801: Decreased performance. It is better to redefine the first function argument as a reference. Consider replacing 'const .. template_ports_element' with 'const .. &template_ports_element'.
  G:\personal_projects\Degate\src\Core\LogicModel\Gate\GateLibraryImporter.cc (89): error V801: Decreased performance. It is better to redefine the first function argument as a reference. Consider replacing 'const .. gt_elem' with 'const .. &gt_elem'.
  G:\personal_projects\Degate\src\Core\LogicModel\Gate\GateLibraryImporter.cc (102): error V801: Decreased performance. It is better to redefine the first function argument as a reference. Consider replacing 'const .. gate_template_element' with 'const .. &gate_template_element'.
  G:\personal_projects\Degate\src\Core\LogicModel\Gate\GatePort.cc (139): error V807: Decreased performance. Consider creating a pointer to avoid using the 'gate.lock()' expression repeatedly.
  G:\personal_projects\Degate\src\Core\LogicModel\Gate\GatePort.cc (113): error V807: Decreased performance. Consider creating a pointer to avoid using the 'gate.lock()' expression repeatedly.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModel.cc (733): error V820: The 'layers' variable is not used after copying. Copying can be replaced with move/swap for optimization.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModelImporter.cc (486): error V801: Decreased performance. It is better to redefine the first function argument as a reference. Consider replacing 'const .. modules_element' with 'const .. &modules_element'.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModelImporter.cc (438): error V801: Decreased performance. It is better to redefine the first function argument as a reference. Consider replacing 'const .. annotations_element' with 'const .. &annotations_element'.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModelImporter.cc (346): error V801: Decreased performance. It is better to redefine the first function argument as a reference. Consider replacing 'const .. gates_element' with 'const .. &gates_element'.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModelImporter.cc (210): error V801: Decreased performance. It is better to redefine the first function argument as a reference. Consider replacing 'const .. wires_element' with 'const .. &wires_element'.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModelImporter.cc (252): error V801: Decreased performance. It is better to redefine the first function argument as a reference. Consider replacing 'const .. vias_element' with 'const .. &vias_element'.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModelImporter.cc (134): error V801: Decreased performance. It is better to redefine the first function argument as a reference. Consider replacing 'const .. nets_element' with 'const .. &nets_element'.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModelImporter.cc (102): error V801: Decreased performance. It is better to redefine the first function argument as a reference. Consider replacing 'const .. lm_elem' with 'const .. &lm_elem'.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModelImporter.cc (304): error V801: Decreased performance. It is better to redefine the first function argument as a reference. Consider replacing 'const .. emarkers_element' with 'const .. &emarkers_element'.
  G:\personal_projects\Degate\src\Core\Matching\TemplateMatching.cc (622): error V801: Decreased performance. It is better to redefine the third function argument as a reference. Consider replacing 'const .. summation_table_squared' with 'const .. &summation_table_squared'.
  G:\personal_projects\Degate\src\Core\Matching\TemplateMatching.cc (621): error V801: Decreased performance. It is better to redefine the second function argument as a reference. Consider replacing 'const .. summation_table_single' with 'const .. &summation_table_single'.
  G:\personal_projects\Degate\src\Core\Matching\TemplateMatching.cc (620): error V801: Decreased performance. It is better to redefine the first function argument as a reference. Consider replacing 'const .. master' with 'const .. &master'.
  G:\personal_projects\Degate\src\Core\Matching\TemplateMatching.cc (544): error V801: Decreased performance. It is better to redefine the eighth function argument as a reference. Consider replacing 'const .. zero_mean_template' with 'const .. &zero_mean_template'.
  G:\personal_projects\Degate\src\Core\Matching\TemplateMatching.cc (784): error V803: Decreased performance. In case 'state->iter_begin' is iterator it's more effective to use prefix form of increment. Replace iterator++ with ++iterator.
  G:\personal_projects\Degate\src\Core\Matching\TemplateMatching.cc (543): error V801: Decreased performance. It is better to redefine the seventh function argument as a reference. Consider replacing 'const .. master' with 'const .. &master'.
  G:\personal_projects\Degate\src\Core\Matching\TemplateMatching.cc (228): error V801: Decreased performance. It is better to redefine the second function argument as a reference. Consider replacing 'const .. rhs' with 'const .. &rhs'.
  G:\personal_projects\Degate\src\Core\Matching\TemplateMatching.cc (228): error V801: Decreased performance. It is better to redefine the first function argument as a reference. Consider replacing 'const .. lhs' with 'const .. &lhs'.
  G:\personal_projects\Degate\src\Core\Matching\TemplateMatching.cc (623): error V801: Decreased performance. It is better to redefine the fourth function argument as a reference. Consider replacing 'const .. zero_mean_template' with 'const .. &zero_mean_template'.
  G:\personal_projects\Degate\src\Core\Primitive\QuadTree.h (261): error V818: It is more efficient to use an initialization list 'box(box)' rather than an assignment operator.
  G:\personal_projects\Degate\src\Core\Primitive\QuadTree.h (252): error V818: It is more efficient to use an initialization list 'box(box)' rather than an assignment operator.
  G:\personal_projects\Degate\src\Core\Project\PortColorManager.h (77): error V813: Decreased performance. The 'port_name' argument should probably be rendered as a constant reference.
  G:\personal_projects\Degate\src\Core\Project\PortColorManager.h (69): error V813: Decreased performance. The 'port_name' argument should probably be rendered as a constant reference.
  G:\personal_projects\Degate\src\Core\Project\Project.cc (168): error V820: The 'version_str' variable is not used after copying. Copying can be replaced with move/swap for optimization.
  G:\personal_projects\Degate\src\Core\Project\Project.cc (156): error V813: Decreased performance. The 'description' argument should probably be rendered as a constant reference.
  G:\personal_projects\Degate\src\Core\Project\Project.cc (166): error V813: Decreased performance. The 'version_str' argument should probably be rendered as a constant reference.
  G:\personal_projects\Degate\src\Core\Project\Project.cc (158): error V820: The 'description' variable is not used after copying. Copying can be replaced with move/swap for optimization.
  G:\personal_projects\Degate\src\Core\RuleCheck\RCVBlacklistImporter.cc (77): error V801: Decreased performance. It is better to redefine the first function argument as a reference. Consider replacing 'const .. elem' with 'const .. &elem'.
  G:\personal_projects\Degate\src\Core\XML\XMLImporter.cc (40): error V801: Decreased performance. It is better to redefine the first function argument as a reference. Consider replacing 'const .. start_node' with 'const .. &start_node'.
  G:\personal_projects\Degate\src\Core\XML\XMLImporter.h (65): error V801: Decreased performance. It is better to redefine the first function argument as a reference. Consider replacing 'const .. node' with 'const .. &node'.
  G:\personal_projects\Degate\src\Core\XML\XMLImporter.h (45): error V801: Decreased performance. It is better to redefine the first function argument as a reference. Consider replacing 'const .. node' with 'const .. &node'.
  G:\personal_projects\Degate\src\GUI\Dialog\AnnotationListDialog.cc (93): error V803: Decreased performance. In case 'it' is iterator it's more effective to use prefix form of increment. Replace iterator++ with ++iterator.
  G:\personal_projects\Degate\src\GUI\Dialog\GateListDialog.cc (104): error V803: Decreased performance. In case 'it' is iterator it's more effective to use prefix form of increment. Replace iterator++ with ++iterator.
  G:\personal_projects\Degate\src\GUI\Dialog\NewProjectDialog.cc (124): error V820: The 'temp_project_directory' variable is not used after copying. Copying can be replaced with move/swap for optimization.
  G:\personal_projects\Degate\src\GUI\Dialog\NewProjectDialog.cc (32): error V818: It is more efficient to use an initialization list 'project_directory(project_path)' rather than an assignment operator.
  G:\personal_projects\Degate\src\GUI\Preferences\PreferencesHandler.cc (311): error V803: Decreased performance. In case 'it' is iterator it's more effective to use prefix form of increment. Replace iterator++ with ++iterator.
  G:\personal_projects\Degate\src\GUI\Preferences\PreferencesHandler.h (41): error V802: On 64-bit platform, structure size can be reduced from 56 to 48 bytes by rearranging the fields according to their sizes in decreasing order.
  G:\personal_projects\Degate\src\GUI\Preferences\PreferencesPage\AppearancePreferencesPage.cc (49): error V807: Decreased performance. Consider creating a reference to avoid using the same expression repeatedly.
  G:\personal_projects\Degate\src\GUI\Preferences\PreferencesPage\GeneralPreferencesPage.cc (45): error V807: Decreased performance. Consider creating a reference to avoid using the same expression repeatedly.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (175): error V815: Decreased performance. Consider replacing the expression 'get_filename_from_path("") == ""' with 'get_filename_from_path("").empty()'.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (190): error V815: Decreased performance. Consider replacing the expression 'get_basename(".conf") == ""' with 'get_basename(".conf").empty()'.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (186): error V815: Decreased performance. Consider replacing the expression 'get_basename("/etc/.conf") == ""' with 'get_basename("/etc/.conf").empty()'.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (182): error V815: Decreased performance. Consider replacing the expression 'get_basename("") == ""' with 'get_basename("").empty()'.
  G:\personal_projects\Degate\src\Core\DOT\LogicModelDOTExporter.cc (241): error V821: Decreased performance. The 'net_name' variable can be constructed in a lower level scope.
  G:\personal_projects\Degate\src\Core\Generator\VerilogCodeTemplateGenerator.cc (406): error V815: Decreased performance. Consider replacing the expression 'prefix == ""' with 'prefix.empty()'.
  G:\personal_projects\Degate\src\Core\Generator\VerilogCodeTemplateGenerator.cc (178): error V815: Decreased performance. Consider replacing the expression 'outer_op = ""' with 'outer_op.clear()'.
  G:\personal_projects\Degate\src\Core\Generator\VerilogModuleGenerator.cc (192): error V821: Decreased performance. The 'tmpl_port' variable can be constructed in a lower level scope.
  G:\personal_projects\Degate\src\Core\Generator\VerilogModuleGenerator.cc (259): error V815: Decreased performance. Consider replacing the expression 'wire_definitions != ""' with '!wire_definitions.empty()'.
  G:\personal_projects\Degate\src\Core\Generator\VerilogTBCodeTemplateGenerator.cc (81): error V826: Consider replacing the 'port_wiring' std::list with std::vector. Contiguous placement of elements in memory can be more efficient.
  G:\personal_projects\Degate\src\Core\Generator\VHDLCodeTemplateGenerator.cc (236): error V826: Consider replacing the 'port_map_str' std::list with std::vector. Contiguous placement of elements in memory can be more efficient.
  G:\personal_projects\Degate\src\Core\Generator\VHDLCodeTemplateGenerator.cc (131): error V815: Decreased performance. Consider replacing the expression 'outer_op = ""' with 'outer_op.clear()'.
  G:\personal_projects\Degate\src\Core\Image\ImageHelper.h (152): error V826: Consider replacing the 'images' std::list with std::vector. Contiguous placement of elements in memory can be more efficient.
  G:\personal_projects\Degate\src\Core\Image\ImageReader.h (85): error V809: Verifying that a pointer value is not NULL is not required. The 'if (image_reader != nullptr)' check can be removed.
  G:\personal_projects\Degate\src\Core\Image\Manipulation\ScalingManager.h (116): error V826: Consider replacing the 'steps' std::list with std::vector. Insertions occur at the back side, and the container is traversed.
  G:\personal_projects\Degate\src\Core\LogicModel\Gate\GateLibraryImporter.cc (212): error V821: Decreased performance. The 'impl_file' variable can be constructed in a lower level scope.
  G:\personal_projects\Degate\src\Core\LogicModel\Gate\GateLibraryImporter.cc (210): error V821: Decreased performance. The 'impl_type_str' variable can be constructed in a lower level scope.
  G:\personal_projects\Degate\src\Core\LogicModel\Gate\GateTemplate.cc (310): error V815: Decreased performance. Consider replacing the expression 'impl_type_str == ""' with 'impl_type_str.empty()'.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModel.cc (602): error V821: Decreased performance. The 'tmpl_port' variable can be constructed in a lower level scope.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModel.cc (546): error V821: Decreased performance. The 'gate_template' variable can be constructed in a lower level scope.
  G:\personal_projects\Degate\src\Core\LogicModel\LogicModelImporter.cc (535): error V821: Decreased performance. The 'port_name' variable can be constructed in a lower level scope.
  G:\personal_projects\Degate\src\Core\Matching\TemplateMatching.cc (142): error V821: Decreased performance. The 'img_scaled' variable can be constructed in a lower level scope.
  G:\personal_projects\Degate\src\Core\Matching\TemplateMatching.cc (146): error V821: Decreased performance. The 'scaled_bounding_box' variable can be constructed in a lower level scope.
  G:\personal_projects\Degate\src\Core\Primitive\Line.cc (87): error V821: Decreased performance. The 'B' variable can be constructed in a lower level scope.
  G:\personal_projects\Degate\src\Core\Primitive\RegionList.h (79): error V821: Decreased performance. The 'tmp_region' variable can be constructed in a lower level scope.
  G:\personal_projects\Degate\src\Core\Project\ProjectExporter.cc (55): error V821: Decreased performance. The 'oid_rewriter' variable can be constructed in a lower level scope.
  G:\personal_projects\Degate\src\Core\Utils\MemoryMap.h (245): error V809: Verifying that a pointer value is not NULL is not required. The 'if (mem_view != nullptr)' check can be removed.
  G:\personal_projects\Degate\src\GUI\Dialog\ColorPickerDialog.cc (104): error V807: Decreased performance. Consider creating a reference to avoid using the 'color_dialog.currentColor()' expression repeatedly.
  G:\personal_projects\Degate\src\GUI\Dialog\ConnectionInspector.cc (126): error V807: Decreased performance. Consider creating a reference to avoid using the 'connections_table.selectedItems()' expression repeatedly.
  G:\personal_projects\Degate\src\GUI\Dialog\ModulesDialog.cc (301): error V807: Decreased performance. Consider creating a reference to avoid using the 'modules_tree.selectedItems()' expression repeatedly.
  G:\personal_projects\Degate\src\GUI\Preferences\PreferencesHandler.cc (180): error V815: Decreased performance. Consider replacing the expression 'locale == ""' with 'locale.isEmpty()'.
  G:\personal_projects\Degate\src\GUI\Preferences\ThemeManager.cc (65): error V807: Decreased performance. Consider creating a pointer to avoid using the same expression repeatedly.
  G:\personal_projects\Degate\src\GUI\Widget\LayersEditWidget.cc (342): error V807: Decreased performance. Consider creating a pointer to avoid using the 'project->get_logic_model()' expression repeatedly.
  G:\personal_projects\Degate\src\GUI\Widget\LayersEditWidget.cc (259): error V807: Decreased performance. Consider creating a reference to avoid using the 'background->get_image_path()' expression repeatedly.
  G:\personal_projects\Degate\tests\src\FileSystemTests.cc (137): error V826: Consider replacing the 'files' std::list with std::vector. Contiguous placement of elements in memory can be more efficient.
  ```
</details>
