### PR TITLE
Remove usages of BOOST_FOREACH.

### DIFF
--- a/src/Core/Generator/CodeTemplateGenerator.cc
+++ b/src/Core/Generator/CodeTemplateGenerator.cc
@@ -20,12 +20,10 @@
  */
 
 #include "Core/Generator/CodeTemplateGenerator.h"
-#include <boost/foreach.hpp>
 #include <algorithm>
 #include <string>
 
 using namespace degate;
-using namespace boost;
 
 CodeTemplateGenerator::CodeTemplateGenerator(std::string const& entity_name,
                                              std::string const& description,
@@ -112,7 +110,7 @@ std::string CodeTemplateGenerator::get_first_port_name_not_in(std::vector<std::s
 {
     typedef std::vector<std::string>::const_iterator iter;
 
-    BOOST_FOREACH(std::string const& p_name, ports)
+    for (const auto& p_name : ports)
     {
         iter i = std::find(blacklist.begin(), blacklist.end(), p_name);
         if (i == blacklist.end()) return p_name;
@@ -133,8 +131,11 @@ std::vector<std::string> CodeTemplateGenerator::get_inports() const
 {
     std::vector<std::string> ports;
 
-    BOOST_FOREACH(port_direction_type::value_type const& p, port_direction)
-        if (p.second == true) ports.push_back(p.first);
+    for(const auto& p : port_direction)
+    {
+        if (p.second == true)
+            ports.push_back(p.first);
+    }
 
     std::sort(ports.begin(), ports.end());
     return ports;
@@ -144,8 +145,11 @@ std::vector<std::string> CodeTemplateGenerator::get_outports() const
 {
     std::vector<std::string> ports;
 
-    BOOST_FOREACH(port_direction_type::value_type const& p, port_direction)
-        if (p.second == false) ports.push_back(p.first);
+    for (const auto& p : port_direction)
+    {
+        if (p.second == false)
+            ports.push_back(p.first);
+    }
 
     std::sort(ports.begin(), ports.end());
     return ports;
@@ -155,8 +159,10 @@ std::vector<std::string> CodeTemplateGenerator::get_ports() const
 {
     std::vector<std::string> ports;
 
-    BOOST_FOREACH(port_direction_type::value_type const& p, port_direction)
+    for (const auto& p : port_direction)
+    {
         ports.push_back(p.first);
+    }
 
     std::sort(ports.begin(), ports.end());
     return ports;

--- a/src/Core/Generator/CodeTemplateGenerator.h
+++ b/src/Core/Generator/CodeTemplateGenerator.h
@@ -27,8 +27,6 @@
 #include <vector>
 #include <string>
 
-#include <boost/foreach.hpp>
-
 namespace degate
 {
     /**
@@ -101,7 +99,7 @@ namespace degate
         Container generate_identifier(Container const& c, std::string const& prefix = "") const
         {
             Container new_c;
-            BOOST_FOREACH(typename Container::value_type const& s, c)
+            for (const auto& s : c)
             {
                 new_c.push_back(generate_identifier(s, prefix));
             }

--- a/src/Core/Generator/VHDLCodeTemplateGenerator.cc
+++ b/src/Core/Generator/VHDLCodeTemplateGenerator.cc
@@ -22,7 +22,6 @@
 
 #include "Core/Generator/VHDLCodeTemplateGenerator.h"
 #include <boost/format.hpp>
-#include <boost/foreach.hpp>
 #include <boost/algorithm/string/join.hpp>
 #include <list>
 
@@ -210,7 +209,7 @@ std::string VHDLCodeTemplateGenerator::generate_identifier(std::string const& na
     std::string identifier = prefix;
 
     bool first_char = true;
-    BOOST_FOREACH(char c, name)
+    for (auto c : name)
     {
         if (c == '/' || c == '!') identifier.append("not");
         else if (first_char && !isalpha(c))
@@ -233,7 +232,7 @@ std::string VHDLCodeTemplateGenerator::generate_instance(std::string const& inst
 {
     std::list<std::string> port_map_str;
 
-    BOOST_FOREACH(port_map_type::value_type p, port_map)
+    for (auto p : port_map)
     {
         boost::format m("    %1% => %2%");
         m % generate_identifier(p.first) % generate_identifier(p.second);

--- a/src/Core/Generator/VHDLCodeTemplateGenerator.h
+++ b/src/Core/Generator/VHDLCodeTemplateGenerator.h
@@ -26,7 +26,6 @@
 #include <cctype>
 
 #include "Core/Generator/CodeTemplateGenerator.h"
-#include <boost/foreach.hpp>
 
 namespace degate
 {

--- a/src/Core/Generator/VHDLTBCodeTemplateGenerator.cc
+++ b/src/Core/Generator/VHDLTBCodeTemplateGenerator.cc
@@ -22,7 +22,6 @@
 
 #include "Core/Generator/VHDLTBCodeTemplateGenerator.h"
 #include <boost/format.hpp>
-#include <boost/foreach.hpp>
 #include <boost/algorithm/string/join.hpp>
 #include <iostream>
 
@@ -46,8 +45,12 @@ std::string VHDLTBCodeTemplateGenerator::generate() const
     tb_entity_name += entity_name;
 
     port_map_type port_map;
-    BOOST_FOREACH(std::string const& port_name, get_inports()) port_map[port_name] = port_name;
-    BOOST_FOREACH(std::string const& port_name, get_outports()) port_map[port_name] = port_name;
+    for (const auto& port_name : get_inports()) {
+        port_map[port_name] = port_name;
+    }
+    for (const auto& port_name : get_outports()) {
+        port_map[port_name] = port_name;
+    }
 
 
     std::string clock_process_impl;

--- a/src/Core/Generator/VHDLTBCodeTemplateGenerator.h
+++ b/src/Core/Generator/VHDLTBCodeTemplateGenerator.h
@@ -26,7 +26,6 @@
 #include <cctype>
 
 #include "Core/Generator/VHDLCodeTemplateGenerator.h"
-#include <boost/foreach.hpp>
 
 namespace degate
 {

--- a/src/Core/Generator/VerilogCodeTemplateGenerator.cc
+++ b/src/Core/Generator/VerilogCodeTemplateGenerator.cc
@@ -24,7 +24,6 @@
 #include "Core/Utils/DegateExceptions.h"
 
 #include <boost/format.hpp>
-#include <boost/foreach.hpp>
 #include <boost/algorithm/string/join.hpp>
 
 using namespace boost;
@@ -97,7 +96,7 @@ std::string VerilogCodeTemplateGenerator::generate_port_definition() const
     std::string ret;
 
     ret += "  // input ports\n";
-    BOOST_FOREACH(std::string const& port_name,
+    for (const auto& port_name :
                   generate_identifier<std::vector<std::string> >(get_inports()))
     {
         boost::format f("  input %1%;\n");
@@ -107,7 +106,7 @@ std::string VerilogCodeTemplateGenerator::generate_port_definition() const
 
 
     ret += "\n  // output ports\n";
-    BOOST_FOREACH(std::string const& port_name,
+    for (const auto& port_name :
                   generate_identifier<std::vector<std::string> >(get_outports()))
     {
         boost::format f("  output %1%;\n");
@@ -327,7 +326,7 @@ std::string VerilogCodeTemplateGenerator::generate_impl(std::string const& logic
         logic_class == "oai")
     {
         std::string ret;
-        BOOST_FOREACH(std::string const& oport,
+        for (const auto& oport :
                       generate_identifier<std::vector<std::string> >(get_outports()))
         {
             boost::format f("  assign %1% = ...;\n");
@@ -402,7 +401,7 @@ std::string VerilogCodeTemplateGenerator::generate_identifier(std::string const&
     std::string identifier = prefix;
 
     bool first_char = prefix == "" ? true : false;
-    BOOST_FOREACH(char c, name)
+    for (auto c : name)
     {
         if (c == '/' || c == '!' || c == '~') identifier.append("not");
         else if (first_char && !isalpha(c))

--- a/src/Core/Generator/VerilogCodeTemplateGenerator.h
+++ b/src/Core/Generator/VerilogCodeTemplateGenerator.h
@@ -26,7 +26,6 @@
 #include <cctype>
 
 #include "Core/Generator/CodeTemplateGenerator.h"
-#include <boost/foreach.hpp>
 
 namespace degate
 {

--- a/src/Core/Generator/VerilogModuleGenerator.cc
+++ b/src/Core/Generator/VerilogModuleGenerator.cc
@@ -22,7 +22,6 @@
 
 #include "Core/Generator/VerilogModuleGenerator.h"
 #include <boost/format.hpp>
-#include <boost/foreach.hpp>
 #include <boost/algorithm/string/join.hpp>
 
 using namespace boost;
@@ -167,7 +166,7 @@ std::string VerilogModuleGenerator::generate_impl(std::string const& logic_class
 
 
     // genereate wire definitions
-    BOOST_FOREACH(net_names_table::value_type const& v, nets)
+    for (const auto& v : nets)
     {
         if (!mod->exists_module_port_name(v.second))
             wire_definitions += "  wire " + v.second + ";\n";

--- a/src/Core/Generator/VerilogTBCodeTemplateGenerator.cc
+++ b/src/Core/Generator/VerilogTBCodeTemplateGenerator.cc
@@ -22,7 +22,6 @@
 
 #include "Core/Generator/VerilogTBCodeTemplateGenerator.h"
 #include <boost/format.hpp>
-#include <boost/foreach.hpp>
 #include <boost/algorithm/string/join.hpp>
 #include <list>
 #include <boost/lexical_cast.hpp>
@@ -44,10 +43,14 @@ VerilogTBCodeTemplateGenerator::~VerilogTBCodeTemplateGenerator()
 std::string VerilogTBCodeTemplateGenerator::generate() const
 {
     port_map_type port_map;
-    BOOST_FOREACH(std::string const& port_name, get_inports())
+    for (const auto& port_name : get_inports())
+    {
         port_map[port_name] = port_name;
-    BOOST_FOREACH(std::string const& port_name, get_outports())
+    }
+    for (const auto& port_name : get_outports())
+    {
         port_map[port_name] = port_name;
+    }
 
     return
         generate_header() +
@@ -77,8 +80,7 @@ std::string VerilogTBCodeTemplateGenerator::generate_module(std::string const& d
         boost::algorithm::join(generate_identifier<std::vector<std::string>>(get_outports()), ", ");
 
     std::list<std::string> port_wiring;
-    BOOST_FOREACH(std::string const & pname,
-                  generate_identifier(get_ports()))
+    for (const auto& pname : generate_identifier(get_ports()))
     {
         boost::format f(".%1%(%2%)");
         f % pname % pname;
@@ -86,8 +88,7 @@ std::string VerilogTBCodeTemplateGenerator::generate_module(std::string const& d
     }
 
     std::string inport_init;
-    BOOST_FOREACH(std::string const & pname,
-                  generate_identifier(get_inports()))
+    for (const auto& pname : generate_identifier(get_inports()))
     {
         boost::format f("    %1% <= 1'b0;\n");
         f % pname;
@@ -193,8 +194,10 @@ std::string VerilogTBCodeTemplateGenerator::generate_all_assignments
     while (increment(assignment))
     {
         std::string assignment2;
-        BOOST_FOREACH(int i, assignment)
+        for (auto i : assignment)
+        {
             assignment2.push_back(boost::lexical_cast<char>(i));
+        }
         std::reverse(assignment2.begin(), assignment2.end());
 
         // generate assignemt string
@@ -203,8 +206,7 @@ std::string VerilogTBCodeTemplateGenerator::generate_all_assignments
         f % assignment_dst % prefix % assignment2;
 
         testcode += f.str();
-        BOOST_FOREACH(std::string const& oport,
-                      generate_identifier<std::vector<std::string> >(out_port_idents))
+        for (const auto& oport : generate_identifier<std::vector<std::string> >(out_port_idents))
         {
             boost::format f2("    assert(%1% === 1'bX); // please edit\n\n");
             f2 % oport;

--- a/src/Core/Generator/VerilogTBCodeTemplateGenerator.h
+++ b/src/Core/Generator/VerilogTBCodeTemplateGenerator.h
@@ -26,7 +26,6 @@
 #include <cctype>
 
 #include "Core/Generator/VerilogCodeTemplateGenerator.h"
-#include <boost/foreach.hpp>
 
 namespace degate
 {

--- a/src/Core/Image/ImageHelper.h
+++ b/src/Core/Image/ImageHelper.h
@@ -30,7 +30,6 @@
 #include "Core/Image/ImageReader.h"
 
 #include <set>
-#include <boost/foreach.hpp>
 
 namespace degate
 {
@@ -159,7 +158,7 @@ namespace degate
         unsigned int w = img->get_width(), h = img->get_height();
         std::vector<double> i_tmp(4 * static_cast<std::size_t>(w) * static_cast<std::size_t>(h));
 
-        BOOST_FOREACH(const std::shared_ptr<ImageType> i, images)
+        for (const auto& i : images)
         {
             // verify that all images have the same dimensions
             if (w != i->get_width() || h != i->get_height())

--- a/src/Core/LogicModel/ConnectedLogicModelObject.cc
+++ b/src/Core/LogicModel/ConnectedLogicModelObject.cc
@@ -27,8 +27,6 @@
 #include "Net.h"
 #include "ConnectedLogicModelObject.h"
 
-#include <boost/foreach.hpp>
-
 using namespace degate;
 
 ConnectedLogicModelObject::ConnectedLogicModelObject()
@@ -80,7 +78,7 @@ bool ConnectedLogicModelObject::is_connected() const
 {
     if (net == nullptr) return false;
     if (net->size() >= 2) return true;
-    BOOST_FOREACH(object_id_t oid, *net)
+    for (auto oid : *net)
     {
         if (oid != get_object_id()) return true;
     }

--- a/src/Core/LogicModel/Gate/AutoNameGates.cc
+++ b/src/Core/LogicModel/Gate/AutoNameGates.cc
@@ -23,8 +23,6 @@
 #include "Core/LogicModel/LogicModelHelper.h"
 #include "Core/LogicModel/Layer.h"
 
-#include <boost/foreach.hpp>
-
 using namespace degate;
 
 bool compare_min_x(const Gate_shptr lhs, const Gate_shptr rhs)
@@ -58,7 +56,7 @@ void AutoNameGates::rename_gates(std::vector<unsigned int> const& histogram, std
     unsigned int col_num = 1;
     unsigned int row_num = 1;
 
-    BOOST_FOREACH(int i, scan_lines)
+    for (auto i : scan_lines)
     {
         // naming = along-rows => histogram along y-axis, following scanlines along x-axis
 
@@ -85,7 +83,7 @@ void AutoNameGates::rename_gates(std::vector<unsigned int> const& histogram, std
             gate_list.sort(compare_min_y);
 
         // rename gates
-        BOOST_FOREACH(Gate_shptr gate, gate_list)
+        for (auto gate : gate_list)
         {
             boost::format f("%1%.%2%");
             f % row_num % col_num;

--- a/src/Core/LogicModel/LogicModel.cc
+++ b/src/Core/LogicModel/LogicModel.cc
@@ -28,7 +28,6 @@
 #include "Core/LogicModel/LogicModel.h"
 
 #include <algorithm>
-#include <boost/foreach.hpp>
 #include <iterator>
 #include <memory>
 
@@ -86,7 +85,7 @@ void LogicModel::print(std::ostream& os)
 
 bool LogicModel::exists_layer_id(layer_collection const& layers, layer_id_t lid) const
 {
-    BOOST_FOREACH(Layer_shptr l, layers)
+    for (auto l : layers)
     {
         if (l != nullptr && l->has_valid_layer_id() && l->get_layer_id() == lid)
             return true;
@@ -381,7 +380,7 @@ void LogicModel::remove_remote_object(object_id_t remote_id)
 
     debug(TM, "Should remove object with remote ID %llu from lmodel - 2.", remote_id);
 
-    BOOST_FOREACH(object_collection::value_type const& p, objects)
+    for (const auto& p : objects)
     {
         PlacedLogicModelObject_shptr plo = p.second;
         RemoteObject_shptr ro;
@@ -692,7 +691,7 @@ Layer_shptr LogicModel::get_layer(layer_position_t pos)
 
 Layer_shptr LogicModel::get_layer_by_id(layer_id_t lid)
 {
-    BOOST_FOREACH(Layer_shptr l, layers)
+    for (auto l : layers)
     {
         if (l->has_valid_layer_id() && l->get_layer_id() == lid)
             return l;
@@ -726,7 +725,10 @@ void LogicModel::set_layers(layer_collection layers)
         }
     }
 
-    BOOST_FOREACH(Layer_shptr l, layers_to_remove) remove_layer(l);
+    for (auto l : layers_to_remove)
+    {
+        remove_layer(l);
+    }
 
     // set new layers
     this->layers = layers;
@@ -747,7 +749,10 @@ void LogicModel::remove_layer(Layer_shptr layer)
         remove_list.push_back(*i);
 
     // Remove objects from logic model.
-    BOOST_FOREACH(PlacedLogicModelObject_shptr o, remove_list) remove_object(o);
+    for (auto o : remove_list)
+    {
+        remove_object(o);
+    }
 
     // Unset background image. It will remove the image files, too.
     layer->unset_image();

--- a/src/Core/LogicModel/LogicModelHelper.cc
+++ b/src/Core/LogicModel/LogicModelHelper.cc
@@ -26,7 +26,6 @@
 #include "GUI/Preferences/PreferencesHandler.h"
 
 #include <boost/format.hpp>
-#include <boost/foreach.hpp>
 #include <boost/range/counting_range.hpp>
 
 #include <QMutex>
@@ -742,7 +741,7 @@ void degate::merge_gate_images(LogicModel_shptr lmodel,
 
     std::list<GateTemplateImage_shptr> images;
 
-    BOOST_FOREACH(const Gate_shptr g, gates)
+    for (const auto& g : gates)
     {
         GateTemplateImage_shptr tmpl_img =
             grab_image<GateTemplateImage>(lmodel, layer, g->get_bounding_box());
@@ -783,7 +782,7 @@ void degate::merge_gate_images(LogicModel_shptr lmodel,
     typedef std::map<object_id_t, std::list<Gate_shptr>> gate_sets_type;
     gate_sets_type gate_sets;
 
-    BOOST_FOREACH(PlacedLogicModelObject_shptr plo, gates)
+    for (auto plo : gates)
     {
         if (Gate_shptr gate = std::dynamic_pointer_cast<Gate>(plo))
         {
@@ -797,7 +796,7 @@ void degate::merge_gate_images(LogicModel_shptr lmodel,
      * Iterate over layers.
      */
 
-    BOOST_FOREACH(Layer_shptr layer, get_available_standard_layers(lmodel))
+    for (auto layer : get_available_standard_layers(lmodel))
     {
         /*
          * Iterate over standard cell classes.
@@ -815,7 +814,7 @@ void degate::merge_gate_images(LogicModel_shptr lmodel,
 
 void degate::remove_entire_net(LogicModel_shptr lmodel, Net_shptr net)
 {
-    BOOST_FOREACH(object_id_t oid, *net)
+    for (auto oid : *net)
     {
         PlacedLogicModelObject_shptr plo = lmodel->get_object(oid);
         assert(plo != nullptr);

--- a/src/Core/LogicModel/LogicModelImporter.cc
+++ b/src/Core/LogicModel/LogicModelImporter.cc
@@ -33,7 +33,6 @@
 #include <list>
 
 #include <boost/format.hpp>
-#include <boost/foreach.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
 
 using namespace std;
@@ -75,7 +74,7 @@ void LogicModelImporter::import_into(LogicModel_shptr lmodel,
         parse_logic_model_element(root_elem, lmodel);
 
         // check if the ports of placed standard cell are available and create them if necessary
-        BOOST_FOREACH(Gate_shptr g, gates)
+        for (auto g : gates)
         {
             lmodel->update_ports(g);
         }
@@ -546,7 +545,10 @@ std::list<Module_shptr> LogicModelImporter::parse_modules_element(QDomElement co
         if (!sub_modules_elem.isNull())
         {
             std::list<Module_shptr> sub_modules = parse_modules_element(sub_modules_elem, lmodel);
-            BOOST_FOREACH(Module_shptr submod, sub_modules) module->add_module(submod);
+            for (auto submod : sub_modules)
+            {
+                module->add_module(submod);
+            }
         }
 
         modules.push_back(module);

--- a/src/Core/LogicModel/LookupSubcircuit.h
+++ b/src/Core/LogicModel/LookupSubcircuit.h
@@ -28,8 +28,6 @@
 
 #include "Core/LogicModel/LogicModelHelper.h"
 
-#include <boost/foreach.hpp>
-
 namespace degate
 {
     class LookupSubcircuit
@@ -98,7 +96,7 @@ namespace degate
 
             std::set<Gate_shptr> other_gates;
 
-            BOOST_FOREACH(Gate_shptr g,
+            for (auto g :
                           filter_connected_gates(start_gate, GateTemplatePort::PORT_TYPE_OUT, "Q",
                               "flipflop", GateTemplatePort::PORT_TYPE_IN, "D"))
                 if (closed_list.find(g) != closed_list.end())
@@ -107,7 +105,7 @@ namespace degate
                     closed_list.insert(g);
                 }
 
-            BOOST_FOREACH(Gate_shptr g,
+            for (auto g :
                           filter_connected_gates(start_gate, GateTemplatePort::PORT_TYPE_IN, "D",
                               "flipflop", GateTemplatePort::PORT_TYPE_OUT, "Q"))
                 if (closed_list.find(g) != closed_list.end())
@@ -116,7 +114,7 @@ namespace degate
                     closed_list.insert(g);
                 }
 
-            BOOST_FOREACH(Gate_shptr g2, other_gates)
+            for (auto g2 : other_gates)
             {
                 std::cout << "\tGate " << g2->get_descriptive_identifier() << std::endl;
 
@@ -148,7 +146,7 @@ namespace degate
                     Net_shptr net = gport->get_net();
                     if (net != nullptr)
                     {
-                        BOOST_FOREACH(object_id_t oid, *net)
+                        for (auto oid : *net)
                         {
                             if (oid != gport->get_object_id())
                             {

--- a/src/Core/LogicModel/Module.cc
+++ b/src/Core/LogicModel/Module.cc
@@ -21,7 +21,6 @@
  */
 
 #include "Core/LogicModel/Module.h"
-#include <boost/foreach.hpp>
 #include <boost/algorithm/string.hpp>
 
 #include <iterator>
@@ -399,9 +398,9 @@ void Module::determine_module_ports()
 
 
     // check sub-modules
-    BOOST_FOREACH(Module_shptr sub, modules)
+    for (auto sub : modules)
     {
-        BOOST_FOREACH(port_collection::value_type const& p, sub->ports)
+        for (const auto& p : sub->ports)
         {
             std::string mod_port_name = p.first;
             GatePort_shptr gate_port = p.second;
@@ -552,7 +551,7 @@ Module_shptr Module::lookup_module(std::list<std::string>& path_elements) const
 {
     if (path_elements.size() > 0)
     {
-        BOOST_FOREACH(Module_shptr m, modules)
+        for (auto m : modules)
         {
             if (m->get_name() == path_elements.front())
             {

--- a/src/Core/LogicModel/ObjectSet.h
+++ b/src/Core/LogicModel/ObjectSet.h
@@ -27,7 +27,6 @@
 #include <set>
 #include <list>
 #include <memory>
-#include <boost/foreach.hpp>
 
 namespace degate
 {
@@ -87,7 +86,7 @@ namespace degate
         {
             if (empty()) return false;
 
-            BOOST_FOREACH(PlacedLogicModelObject_shptr o, objects)
+            for (auto o : objects)
             {
                 if (check_function(o) == false) return false;
             }

--- a/src/Core/Matching/ExternalMatching.cc
+++ b/src/Core/Matching/ExternalMatching.cc
@@ -101,8 +101,7 @@ void ExternalMatching::run()
     }
     else
     {
-        BOOST_FOREACH(PlacedLogicModelObject_shptr plo,
-                      parse_file(results_file))
+        for (auto plo : parse_file(results_file))
         {
             lmodel->add_object(layer, plo);
         }

--- a/src/Core/Matching/LineSegmentExtraction.h
+++ b/src/Core/Matching/LineSegmentExtraction.h
@@ -28,8 +28,6 @@
 #include <memory>
 #include <fstream>
 
-#include <boost/foreach.hpp>
-
 namespace degate
 {
     // ----------------------------------------------------------------------------------
@@ -194,7 +192,7 @@ namespace degate
                                         unsigned int search_radius_along,
                                         unsigned int search_radius_across) const
         {
-            BOOST_FOREACH(LineSegment_shptr elem2, *this)
+            for (auto elem2 : *this)
             {
                 if (elem != elem2 && elem2->get_orientation() == elem->get_orientation())
                 {
@@ -289,7 +287,7 @@ namespace degate
             std::ofstream myfile;
             myfile.open("/tmp/example.txt");
 
-            BOOST_FOREACH(LineSegment_shptr e, *this)
+            for (auto e : *this)
             {
                 if (e->get_length() > 0)
                 {

--- a/src/Core/Matching/TemplateMatching.cc
+++ b/src/Core/Matching/TemplateMatching.cc
@@ -31,7 +31,6 @@
 #include <memory>
 
 #include <utility>
-#include <boost/foreach.hpp>
 #include <cmath>
 
 using namespace degate;
@@ -269,9 +268,9 @@ void TemplateMatching::run()
   
     wait;
     */
-    BOOST_FOREACH(GateTemplate_shptr tmpl, tmpl_set)
+    for (auto tmpl : tmpl_set)
     {
-        BOOST_FOREACH(Gate::ORIENTATION orientation, tmpl_orientations)
+        for (auto orientation : tmpl_orientations)
         {
             boost::format f("Check cell \"%1%\"");
             f % tmpl->get_name();
@@ -300,7 +299,7 @@ void TemplateMatching::run()
 
     matches.sort(compare_correlation);
 
-    BOOST_FOREACH(match_found const& m, matches)
+    for (const auto& m : matches)
     {
         std::cout << "Try to insert gate of type " << m.tmpl->get_name() << " with corr="
             << m.correlation << " at " << m.x << "," << m.y << std::endl;

--- a/src/Core/Matching/ViaMatching.cc
+++ b/src/Core/Matching/ViaMatching.cc
@@ -24,7 +24,6 @@
 #include "Core/Matching/EdgeDetection.h"
 #include "Core/Matching/ViaMatching.h"
 #include "Core/Primitive/BoundingBox.h"
-#include <boost/foreach.hpp>
 #include <memory>
 
 
@@ -291,7 +290,7 @@ void ViaMatching::scan(BoundingBox const& bbox, BackgroundImage_shptr bg_img,
     }
 
     matches.sort(compare_correlation);
-    BOOST_FOREACH(match_found const& m, matches)
+    for (const auto& m : matches)
     {
         add_via(m.x, m.y, via_diameter, direction, m.correlation, threshold_match);
     }

--- a/src/Core/Matching/WireMatching.cc
+++ b/src/Core/Matching/WireMatching.cc
@@ -27,7 +27,6 @@
 #include "Core/Primitive/BoundingBox.h"
 #include "Core/Matching/LineSegmentExtraction.h"
 #include "Core/Image/Manipulation/MedianFilter.h"
-#include <boost/foreach.hpp>
 
 using namespace degate;
 
@@ -107,7 +106,7 @@ void WireMatching::run()
     assert(lmodel != nullptr);
     assert(layer != nullptr);
 
-    BOOST_FOREACH (LineSegment_shptr ls, *line_segments)
+    for (auto ls : *line_segments)
     {
         debug(TM, "found wire");
         Wire_shptr w(new Wire(bounding_box.get_min_x() + ls->get_from_x(),

--- a/src/Core/Project/ProjectArchiver.cc
+++ b/src/Core/Project/ProjectArchiver.cc
@@ -29,7 +29,6 @@
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/format.hpp>
-#include <boost/foreach.hpp>
 
 /*
 using namespace std;

--- a/src/Core/RuleCheck/ERC/ERCNet.h
+++ b/src/Core/RuleCheck/ERC/ERCNet.h
@@ -22,7 +22,6 @@
 #ifndef __ERCNET_H__
 #define __ERCNET_H__
 
-#include <boost/foreach.hpp>
 #include <memory>
 #include <list>
 #include "Core/LogicModel/LogicModel.h"

--- a/src/Core/RuleCheck/RCBase.h
+++ b/src/Core/RuleCheck/RCBase.h
@@ -22,7 +22,6 @@
 #ifndef __RCBASE_H__
 #define __RCBASE_H__
 
-#include <boost/foreach.hpp>
 #include <memory>
 #include <list>
 #include "Core/LogicModel/LogicModel.h"

--- a/src/Core/RuleCheck/RCVBlacklistExporter.cc
+++ b/src/Core/RuleCheck/RCVBlacklistExporter.cc
@@ -45,7 +45,7 @@ void RCVBlacklistExporter::export_data(std::string const& filename,
         QDomElement root_elem = doc.createElement("rc-blacklist");
         assert(!root_elem.isNull());
 
-        BOOST_FOREACH(RCViolation_shptr rcv, violations)
+        for (auto rcv : violations)
         {
             add_rcv(doc, root_elem, rcv);
         }

--- a/src/Core/RuleCheck/RCVContainer.h
+++ b/src/Core/RuleCheck/RCVContainer.h
@@ -22,7 +22,6 @@
 #ifndef __RCVCONTAINER_H__
 #define __RCVCONTAINER_H__
 
-#include <boost/foreach.hpp>
 #include <memory>
 #include <list>
 

--- a/src/Core/RuleCheck/RCViolation.h
+++ b/src/Core/RuleCheck/RCViolation.h
@@ -22,7 +22,6 @@
 #ifndef __RCVIOLATION_H__
 #define __RCVIOLATION_H__
 
-#include <boost/foreach.hpp>
 #include <memory>
 #include <list>
 #include "Core/LogicModel/LogicModel.h"

--- a/src/Core/RuleCheck/RuleChecker.h
+++ b/src/Core/RuleCheck/RuleChecker.h
@@ -50,10 +50,10 @@ namespace degate
 
             rc_violations.clear();
 
-            BOOST_FOREACH(RCBase_shptr check, checks)
+            for (auto check : checks)
             {
                 check->run(lmodel);
-                BOOST_FOREACH(RCViolation_shptr violation, check->get_rc_violations())
+                for (auto violation : check->get_rc_violations())
                 {
                     rc_violations.push_back(violation);
                 }

--- a/src/Core/Utils/FileSystem.cc
+++ b/src/Core/Utils/FileSystem.cc
@@ -26,7 +26,6 @@
 #include <climits>
 
 #include <boost/filesystem/operations.hpp>
-#include <boost/foreach.hpp>
 #include <iostream>
 #include <string>
 
@@ -378,7 +377,7 @@ boost::filesystem::path degate::strip_path(boost::filesystem::path const& strip_
     path::iterator src_path_end = strip_what.end();
     path stripped;
 
-    BOOST_FOREACH(path s, strip_from)
+    for (auto s : strip_from)
     {
         if (src_path_iter != src_path_end && *src_path_iter == s)
             ++src_path_iter;

--- a/src/GUI/Dialog/GateEditDialog.cc
+++ b/src/GUI/Dialog/GateEditDialog.cc
@@ -368,8 +368,10 @@ namespace degate
 	{
         code_text[languages[language_selector.currentText()]] = text_area.toPlainText().toStdString();
 
-        BOOST_FOREACH(code_text_map_type::value_type &p, code_text)
+        for (auto &p : code_text)
+        {
             gate->set_implementation(static_cast<GateTemplate::IMPLEMENTATION_TYPE>(p.first), p.second);
+        }
 	}
 
     void GateEditBehaviourTab::generate()


### PR DESCRIPTION
## Description

Remove instances of `BOOST_FOREACH` and use standard C++'s "ranged for" looping constructs in their place.

## Affected area(s)

- [x] Core
- [x] GUI
- [ ] Tests

## Changes type

- [ ] Bug fix
- [ ] Migration
- [ ] New feature
- [x] Feature rework 
