### PR TITLE
Use ccache if available to speed up builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,17 @@ cmake_minimum_required(VERSION 3.12.0)
 project(Degate)
 
 #
+# Use ccache if available
+#
+set(DISABLE_CCACHE OFF CACHE BOOL "Do not use ccache even if it is available")
+if (NOT DISABLE_CCACHE)
+    find_program(CCACHE_EXECUTABLE ccache)
+    if (CCACHE_EXECUTABLE)
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${CCACHE_EXECUTABLE})
+    endif()
+endif()
+
+#
 # Cpp version
 #
 set(CMAKE_CXX_STANDARD 11)


### PR DESCRIPTION
## Description

Use ccache to speed up builds if it is available.  ccache usage is enabled by default, but it can be disabled by passing -DDISABLE_CCACHE=ON to the cmake command line or by setting the variable to ON with cmake-gui.

## Affected area(s)

- [x] Core
- [x] GUI
- [x] Tests

## Changes type

- [ ] Bug fix
- [ ] Migration
- [x] New feature
- [ ] Feature rework 

## Proposed changes

- Look for ccache in the user's PATH variable and use it as the default CMake compiler wrapper if it is found.
