### PR TITLE
Use vcpkg for providing dependencies.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vcpkg"]
+	path = vcpkg
+	url = https://github.com/microsoft/vcpkg/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,23 +247,30 @@ endif()
 #
 # Tests
 #
-add_subdirectory(tests)
+include(CTest)
+if(BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif()
 
 
 ############################################################################
 ################################ Doc #######################################
 ############################################################################
 
-find_package(Doxygen QUIET)
-if(DOXYGEN_FOUND)
-    message(STATUS "Doxygen found")
-
-    add_custom_target(Documentation ALL
-            COMMAND ${DOXYGEN_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/doc/config/DoxyFile"
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-            COMMENT "Generating documentation with Doxygen."
-            SOURCES "Degate version")
-
-else()
-    message(STATUS "Doxygen not found")
+if(BUILD_DOCS)
+    find_package(Doxygen QUIET)
+    if(DOXYGEN_FOUND)
+        message(STATUS "Doxygen found")
+    
+        add_custom_target(Documentation ALL
+                COMMAND ${DOXYGEN_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/doc/config/DoxyFile"
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                COMMENT "Generating documentation with Doxygen."
+                SOURCES "Degate version")
+    
+    else()
+        message(STATUS "Doxygen not found")
+    endif()
 endif()
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,8 +19,10 @@
 #
 #####################################################################
 
-enable_testing()
-include_directories("${CMAKE_CURRENT_SOURCE_DIR}/catch2/")
+project(DegateTests LANGUAGES CXX)
+
+find_package(Catch2 CONFIG REQUIRED)
+include(Catch)
 
 #
 # The tests source files
@@ -33,21 +35,10 @@ file(GLOB_RECURSE TEST_SRC_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" LIST_DIR
 )
 
 #
-# Include directories
-#
-include_directories("${CMAKE_CURRENT_SOURCE_DIR}/src")
-include_directories("${CMAKE_CURRENT_SOURCE_DIR}/../src")
-
-#
-# Defines groups (to respect folders hierarchy)
-#
-source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}/src" PREFIX "src" FILES ${TEST_SRC_FILES})
-
-#
 # Link
 #
 add_executable(DegateTests ${TEST_SRC_FILES})
-target_link_libraries(DegateTests ${LIBS} DegateCore)
+target_link_libraries(DegateTests PRIVATE ${LIBS} DegateCore Catch2::Catch2)
 
 #
 # Output specifications
@@ -62,7 +53,6 @@ set_target_properties(DegateTests
 #
 # Link Catch2 tests to CTest
 #
-include(catch2/Catch.cmake)
 catch_discover_tests(DegateTests)
 
 #

--- a/tests/src/FileSystemTests.cc
+++ b/tests/src/FileSystemTests.cc
@@ -22,7 +22,7 @@
 #include "Core/Utils/FileSystem.h"
 #include <fstream>
 
-#include "catch.hpp"
+#include <catch.hpp>
 
 using namespace degate;
 

--- a/tests/src/GateLibraryExporterTests.cc
+++ b/tests/src/GateLibraryExporterTests.cc
@@ -27,7 +27,7 @@
 
 #include <memory>
 
-#include "catch.hpp"
+#include <catch.hpp>
 
 using namespace degate;
 

--- a/tests/src/GateLibraryImporterTests.cc
+++ b/tests/src/GateLibraryImporterTests.cc
@@ -27,7 +27,7 @@
 
 #include <memory>
 
-#include "catch.hpp"
+#include <catch.hpp>
 
 using namespace degate;
 

--- a/tests/src/ImageProcessingTests.cc
+++ b/tests/src/ImageProcessingTests.cc
@@ -23,7 +23,7 @@
 #include "Core/Image/Processor/IPPipe.h"
 #include "Core/Image/Processor/IPCopy.h"
 
-#include "catch.hpp"
+#include <catch.hpp>
 
 using namespace degate;
 

--- a/tests/src/ImageTests.cc
+++ b/tests/src/ImageTests.cc
@@ -24,7 +24,7 @@
 #include "Core/Image/TIFFWriter.h"
 #include "Core/Image/ImageReader.h"
 
-#include "catch.hpp"
+#include <catch.hpp>
 
 using namespace degate;
 

--- a/tests/src/LogicModelDOTExporterTests.cc
+++ b/tests/src/LogicModelDOTExporterTests.cc
@@ -26,7 +26,7 @@
 
 #include <memory>
 
-#include "catch.hpp"
+#include <catch.hpp>
 
 using namespace degate;
 

--- a/tests/src/LogicModelImporterTests.cc
+++ b/tests/src/LogicModelImporterTests.cc
@@ -22,7 +22,7 @@
 #include "Core/LogicModel/Gate/GateLibraryImporter.h"
 #include "Core/LogicModel/LogicModelImporter.h"
 
-#include "catch.hpp"
+#include <catch.hpp>
 
 using namespace degate;
 

--- a/tests/src/LogicModelTests.cc
+++ b/tests/src/LogicModelTests.cc
@@ -22,7 +22,7 @@
 #include "Core/LogicModel/Wire/Wire.h"
 #include "Core/LogicModel/LogicModel.h"
 
-#include "catch.hpp"
+#include <catch.hpp>
 
 using namespace degate;
 

--- a/tests/src/MainTests.cc
+++ b/tests/src/MainTests.cc
@@ -21,7 +21,7 @@
 
 
 #define CATCH_CONFIG_RUNNER
-#include "catch.hpp"
+#include <catch.hpp>
 
 #include <QByteArray>
 #include <QCoreApplication>

--- a/tests/src/MemoryMapTests.cc
+++ b/tests/src/MemoryMapTests.cc
@@ -22,7 +22,7 @@
 #include "Core/Utils/MemoryMap.h"
 #include "Core/Utils/FileSystem.h"
 
-#include "catch.hpp"
+#include <catch.hpp>
 
 using namespace degate;
 

--- a/tests/src/ProjectExporterTests.cc
+++ b/tests/src/ProjectExporterTests.cc
@@ -23,7 +23,7 @@
 #include "Core/Project/ProjectExporter.h"
 #include "Core/Project/Project.h"
 
-#include "catch.hpp"
+#include <catch.hpp>
 
 using namespace degate;
 

--- a/tests/src/ProjectImporterTests.cc
+++ b/tests/src/ProjectImporterTests.cc
@@ -24,7 +24,7 @@
 #include "Core/Project/Project.h"
 #include "Core/LogicModel/LogicModelHelper.h"
 
-#include "catch.hpp"
+#include <catch.hpp>
 
 using namespace degate;
 

--- a/tests/src/QuadTreeTests.cc
+++ b/tests/src/QuadTreeTests.cc
@@ -27,7 +27,7 @@
 #include "Core/Primitive/QuadTree.h"
 #include "Core/LogicModel/Via/Via.h"
 
-#include "catch.hpp"
+#include <catch.hpp>
 
 using namespace degate;
 

--- a/tests/src/ScalingManagerTests.cc
+++ b/tests/src/ScalingManagerTests.cc
@@ -23,7 +23,7 @@
 #include "Core/Image/Image.h"
 #include "Core/Image/ImageReader.h"
 
-#include "catch.hpp"
+#include <catch.hpp>
 
 using namespace degate;
 

--- a/tests/src/ShapeTests.cc
+++ b/tests/src/ShapeTests.cc
@@ -24,7 +24,7 @@
 #include "Core/Primitive/Point.h"
 #include "Core/Primitive/Rectangle.h"
 
-#include "catch.hpp"
+#include <catch.hpp>
 
 using namespace degate;
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,34 @@
+{
+  "name": "degate",
+  "dependencies": [
+    "boost-filesystem",
+    "boost-system",
+    "boost-thread",
+    {
+      "name": "qtbase",
+      "default-features": false,
+      "features": [
+        "concurrent",
+        "gui",
+        "opengl",
+        "widgets"
+      ]
+    },
+    {
+      "name": "qttools",
+      "default-features": false,
+      "features": [
+        "linguist"
+      ]
+    }
+  ],
+  "default-features": [],
+  "features": {
+    "test": {
+      "description": "Dependencies for testing",
+      "dependencies": [
+        "catch2"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Description

Use vcpkg for providing third party dependencies.

## Affected area(s)

- [x] Core
- [x] GUI
- [x] Tests

## Changes type

- [ ] Bug fix
- [ ] Migration
- [x] New feature
- [ ] Feature rework 